### PR TITLE
Feature/open id connect route

### DIFF
--- a/mock-junit/build.gradle
+++ b/mock-junit/build.gradle
@@ -3,6 +3,8 @@ description = 'JUnit4 helper for keycloak-mock'
 dependencies {
     api project(':mock')
     implementation "junit:junit:$junit4_version"
+    // required to mock RoutingContext / Handler
+    testImplementation "io.vertx:vertx-web:$vertx_version"
     testImplementation "io.rest-assured:rest-assured:$restassured_version"
     testImplementation "org.assertj:assertj-core:$assertj_version"
 }

--- a/mock-junit/src/main/java/com/tngtech/keycloakmock/junit/KeycloakMockRule.java
+++ b/mock-junit/src/main/java/com/tngtech/keycloakmock/junit/KeycloakMockRule.java
@@ -1,11 +1,11 @@
 package com.tngtech.keycloakmock.junit;
 
-import javax.annotation.Nonnull;
-import org.junit.rules.ExternalResource;
 import com.tngtech.keycloakmock.api.KeycloakMock;
 import com.tngtech.keycloakmock.api.ServerConfig;
 import com.tngtech.keycloakmock.api.TokenConfig;
 import com.tngtech.keycloakmock.impl.handler.TokenRoute;
+import javax.annotation.Nonnull;
+import org.junit.rules.ExternalResource;
 
 /**
  * A JUnit4 rule to automatically start and stop the keycloak mock.
@@ -71,7 +71,7 @@ public class KeycloakMockRule extends ExternalResource {
   public TokenRoute getTokenRoute() {
     return mock.getTokenRoute();
   }
-  
+
   /**
    * Get a signed access token for the given parameters.
    *

--- a/mock-junit/src/main/java/com/tngtech/keycloakmock/junit/KeycloakMockRule.java
+++ b/mock-junit/src/main/java/com/tngtech/keycloakmock/junit/KeycloakMockRule.java
@@ -1,10 +1,11 @@
 package com.tngtech.keycloakmock.junit;
 
+import javax.annotation.Nonnull;
+import org.junit.rules.ExternalResource;
 import com.tngtech.keycloakmock.api.KeycloakMock;
 import com.tngtech.keycloakmock.api.ServerConfig;
 import com.tngtech.keycloakmock.api.TokenConfig;
-import javax.annotation.Nonnull;
-import org.junit.rules.ExternalResource;
+import com.tngtech.keycloakmock.impl.handler.TokenRoute;
 
 /**
  * A JUnit4 rule to automatically start and stop the keycloak mock.
@@ -50,6 +51,27 @@ public class KeycloakMockRule extends ExternalResource {
     mock = new KeycloakMock(serverConfig);
   }
 
+  /**
+   * Get {@link TokenRoute} handler and control endpoit responses.
+   *
+   * <p>Example use:
+   *
+   * <pre><code>
+   * {@literal //} return error 404
+   * getTokenRoute().withErrorResponse(404, "{\"error\": \"Error detail message\"}")
+   *
+   * {@literal //} return 200
+   * getTokenRoute().withOkResponse(accessTokenConfig, idTokenConfig, refreshTokenConfig, 60 * 60);
+   * </code></pre>
+   *
+   * @return token route handler
+   * @see TokenRoute
+   */
+  @Nonnull
+  public TokenRoute getTokenRoute() {
+    return mock.getTokenRoute();
+  }
+  
   /**
    * Get a signed access token for the given parameters.
    *

--- a/mock-junit/src/test/java/com/tngtech/keycloakmock/junit/KeycloakMockRuleJunit4Test.java
+++ b/mock-junit/src/test/java/com/tngtech/keycloakmock/junit/KeycloakMockRuleJunit4Test.java
@@ -1,13 +1,13 @@
 package com.tngtech.keycloakmock.junit;
 
-import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.matcher.ResponseAwareMatcher;
 import io.restassured.response.Response;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 public class KeycloakMockRuleJunit4Test {
 

--- a/mock-junit/src/test/java/com/tngtech/keycloakmock/junit/KeycloakMockRuleJunit4Test.java
+++ b/mock-junit/src/test/java/com/tngtech/keycloakmock/junit/KeycloakMockRuleJunit4Test.java
@@ -1,10 +1,13 @@
 package com.tngtech.keycloakmock.junit;
 
-import io.restassured.RestAssured;
-import io.restassured.http.ContentType;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.matcher.ResponseAwareMatcher;
+import io.restassured.response.Response;
 
 public class KeycloakMockRuleJunit4Test {
 
@@ -22,6 +25,39 @@ public class KeycloakMockRuleJunit4Test {
         .get("/auth/realms/master/protocol/openid-connect/certs")
         .then()
         .statusCode(200)
+        .and()
+        .contentType(ContentType.JSON);
+  }
+
+  @Test
+  public void token_route_is_working() {
+    RestAssured.when()
+        .post("/auth/realms/master/protocol/openid-connect/token")
+        .then()
+        .statusCode(200)
+        .and()
+        .contentType(ContentType.JSON)
+        .assertThat()
+        .body(
+            "access_token",
+            (ResponseAwareMatcher<Response>) response -> Matchers.blankOrNullString())
+        .body(
+            "refresh_token",
+            (ResponseAwareMatcher<Response>) response -> Matchers.blankOrNullString())
+        .body("id_token", (ResponseAwareMatcher<Response>) response -> Matchers.blankOrNullString())
+        .body(
+            "token_type",
+            (ResponseAwareMatcher<Response>) response -> Matchers.hasToString("Bearer"))
+        .body("expires_in", (ResponseAwareMatcher<Response>) response -> Matchers.equalTo(3600));
+
+    // test error response in same mock
+    keycloakMockRule
+        .getTokenRoute()
+        .withErrorResponse(404, "{\"error\": \"Error detail message\"}");
+    RestAssured.when()
+        .post("/auth/realms/master/protocol/openid-connect/token")
+        .then()
+        .statusCode(404)
         .and()
         .contentType(ContentType.JSON);
   }

--- a/mock-junit5/build.gradle
+++ b/mock-junit5/build.gradle
@@ -4,6 +4,8 @@ dependencies {
     api project(':mock')
     implementation "org.junit.jupiter:junit-jupiter-api:$junit5_version"
     implementation "org.junit.jupiter:junit-jupiter-migrationsupport:$junit5_version"
+    // required to mock RoutingContext / Handler
+    testImplementation "io.vertx:vertx-web:$vertx_version"
     testImplementation "io.rest-assured:rest-assured:$restassured_version"
     testImplementation "org.assertj:assertj-core:$assertj_version"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5_version"

--- a/mock-junit5/src/main/java/com/tngtech/keycloakmock/junit5/KeycloakMockExtension.java
+++ b/mock-junit5/src/main/java/com/tngtech/keycloakmock/junit5/KeycloakMockExtension.java
@@ -1,13 +1,14 @@
 package com.tngtech.keycloakmock.junit5;
 
-import com.tngtech.keycloakmock.api.KeycloakMock;
-import com.tngtech.keycloakmock.api.ServerConfig;
-import com.tngtech.keycloakmock.api.TokenConfig;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import com.tngtech.keycloakmock.api.KeycloakMock;
+import com.tngtech.keycloakmock.api.ServerConfig;
+import com.tngtech.keycloakmock.api.TokenConfig;
+import com.tngtech.keycloakmock.impl.handler.TokenRoute;
 
 /**
  * A JUnit5 extension to be used to automatically start and stop the keycloak mock.
@@ -51,6 +52,26 @@ public class KeycloakMockExtension implements BeforeAllCallback, AfterAllCallbac
    */
   public KeycloakMockExtension(@Nonnull final ServerConfig serverConfig) {
     mock = new KeycloakMock(serverConfig);
+  }
+
+  /**
+   * Get {@link TokenRoute} handler and control endpoit responses.
+   *
+   * <p>Example use:
+   *
+   * <pre><code>
+   * {@literal //} return error 404
+   * getTokenRoute().withErrorResponse(404, "{\"error\": \"Error detail message\"}")
+   *
+   * {@literal //} return 200
+   * getTokenRoute().withOkResponse(accessTokenConfig, idTokenConfig, refreshTokenConfig, 60 * 60);
+   * </code></pre>
+   *
+   * @return token route handler
+   * @see TokenRoute
+   */
+  public TokenRoute getTokenRoute() {
+    return mock.getTokenRoute();
   }
 
   /**

--- a/mock-junit5/src/main/java/com/tngtech/keycloakmock/junit5/KeycloakMockExtension.java
+++ b/mock-junit5/src/main/java/com/tngtech/keycloakmock/junit5/KeycloakMockExtension.java
@@ -1,14 +1,14 @@
 package com.tngtech.keycloakmock.junit5;
 
+import com.tngtech.keycloakmock.api.KeycloakMock;
+import com.tngtech.keycloakmock.api.ServerConfig;
+import com.tngtech.keycloakmock.api.TokenConfig;
+import com.tngtech.keycloakmock.impl.handler.TokenRoute;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import com.tngtech.keycloakmock.api.KeycloakMock;
-import com.tngtech.keycloakmock.api.ServerConfig;
-import com.tngtech.keycloakmock.api.TokenConfig;
-import com.tngtech.keycloakmock.impl.handler.TokenRoute;
 
 /**
  * A JUnit5 extension to be used to automatically start and stop the keycloak mock.

--- a/mock-junit5/src/test/java/com/tngtech/keycloakmock/junit5/KeycloakMockExtensionJunit5Test.java
+++ b/mock-junit5/src/test/java/com/tngtech/keycloakmock/junit5/KeycloakMockExtensionJunit5Test.java
@@ -1,12 +1,14 @@
 package com.tngtech.keycloakmock.junit5;
 
 import static com.tngtech.keycloakmock.api.ServerConfig.aServerConfig;
-
-import io.restassured.RestAssured;
-import io.restassured.http.ContentType;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.matcher.ResponseAwareMatcher;
+import io.restassured.response.Response;
 
 class KeycloakMockExtensionJunit5Test {
   private KeycloakMockExtension keyCloakMockExtension;
@@ -48,5 +50,41 @@ class KeycloakMockExtensionJunit5Test {
         .get("https://localhost:8000/auth/realms/master/protocol/openid-connect/certs")
         .then()
         .statusCode(200);
+  }
+
+  @Test
+  void token_route_is_working() {
+    keyCloakMockExtension = new KeycloakMockExtension();
+    keyCloakMockExtension.beforeAll(null);
+
+    RestAssured.when()
+        .post("/auth/realms/master/protocol/openid-connect/token")
+        .then()
+        .statusCode(200)
+        .and()
+        .contentType(ContentType.JSON)
+        .assertThat()
+        .body(
+            "access_token",
+            (ResponseAwareMatcher<Response>) response -> Matchers.blankOrNullString())
+        .body(
+            "refresh_token",
+            (ResponseAwareMatcher<Response>) response -> Matchers.blankOrNullString())
+        .body("id_token", (ResponseAwareMatcher<Response>) response -> Matchers.blankOrNullString())
+        .body(
+            "token_type",
+            (ResponseAwareMatcher<Response>) response -> Matchers.hasToString("Bearer"))
+        .body("expires_in", (ResponseAwareMatcher<Response>) response -> Matchers.equalTo(3600));
+
+    // test error response in same mock
+    keyCloakMockExtension
+        .getTokenRoute()
+        .withErrorResponse(404, "{\"error\": \"Error detail message\"}");
+    RestAssured.when()
+        .post("/auth/realms/master/protocol/openid-connect/token")
+        .then()
+        .statusCode(404)
+        .and()
+        .contentType(ContentType.JSON);
   }
 }

--- a/mock-junit5/src/test/java/com/tngtech/keycloakmock/junit5/KeycloakMockExtensionJunit5Test.java
+++ b/mock-junit5/src/test/java/com/tngtech/keycloakmock/junit5/KeycloakMockExtensionJunit5Test.java
@@ -1,14 +1,15 @@
 package com.tngtech.keycloakmock.junit5;
 
 import static com.tngtech.keycloakmock.api.ServerConfig.aServerConfig;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.matcher.ResponseAwareMatcher;
 import io.restassured.response.Response;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 class KeycloakMockExtensionJunit5Test {
   private KeycloakMockExtension keyCloakMockExtension;

--- a/mock/src/main/java/com/tngtech/keycloakmock/api/KeycloakMock.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/api/KeycloakMock.java
@@ -82,6 +82,16 @@ public class KeycloakMock {
   /**
    * Get {@link TokenRoute} handler and control endpoit responses.
    *
+   * <p>Example use:
+   *
+   * <pre><code>
+   * {@literal //} return error 404
+   * getTokenRoute().withErrorResponse(404, "{\"error\": \"Error detail message\"}")
+   *
+   * {@literal //} return 200
+   * getTokenRoute().withOkResponse(accessTokenConfig, idTokenConfig, refreshTokenConfig, 60 * 60);
+   * </code></pre>
+   *
    * @return token route handler
    * @see TokenRoute
    */

--- a/mock/src/main/java/com/tngtech/keycloakmock/api/KeycloakMock.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/api/KeycloakMock.java
@@ -1,14 +1,5 @@
 package com.tngtech.keycloakmock.api;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import com.tngtech.keycloakmock.impl.TokenGenerator;
 import com.tngtech.keycloakmock.impl.UrlConfiguration;
 import com.tngtech.keycloakmock.impl.handler.JwksRoute;
@@ -23,6 +14,15 @@ import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.net.JksOptions;
 import io.vertx.ext.web.Router;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A mock of a keycloak instance capable of producing access tokens.

--- a/mock/src/main/java/com/tngtech/keycloakmock/impl/handler/TokenRoute.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/impl/handler/TokenRoute.java
@@ -1,0 +1,101 @@
+package com.tngtech.keycloakmock.impl.handler;
+
+import static com.tngtech.keycloakmock.impl.handler.RequestUrlConfigurationHandler.CTX_REQUEST_CONFIGURATION;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import com.tngtech.keycloakmock.api.TokenConfig;
+import com.tngtech.keycloakmock.impl.TokenGenerator;
+import com.tngtech.keycloakmock.impl.UrlConfiguration;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+
+public class TokenRoute implements Handler<RoutingContext> {
+  private TokenConfig accessTokenConfig;
+  private TokenConfig idTokenConfig;
+  private TokenConfig refreshTokenConfig;
+  private int statusCode = 200;
+  private int expiresIn = 3600;
+  private String errorBody;
+  private final TokenGenerator tokenGenerator = new TokenGenerator();
+
+  /**
+   * Change token endpoint to return error response.
+   *
+   * @param statusCode Http status to be returned: Example 404.
+   * @param errorBody body to be returned.
+   * @return TokenRoute
+   */
+  public TokenRoute withErrorResponse(@Nonnull int statusCode, @Nonnull String errorBody) {
+    this.statusCode = statusCode;
+    this.errorBody = errorBody;
+    this.accessTokenConfig = null;
+    this.idTokenConfig = null;
+    this.refreshTokenConfig = null;
+    return this;
+  }
+
+  /**
+   * Changes token endpoint to return a successful response (http status = 200) and body with
+   * TokenResponse.
+   *
+   * @param accessTokenConfig TokenConfig to use when generate access token.
+   * @param idTokenConfig TokenConfig to use when generate idToken. If null id_token will be a empty
+   *     string
+   * @param refreshTokenConfig TokenConfig to use when generate refresh token. If null refresh_token
+   *     will be a empty string
+   * @param expiresIn Token expires, in seconds. If null will be used as default 3600
+   * @see TokenConfig.Builder
+   * @see <a href="https://openid.net/specs/openid-connect-core-1_0.html#TokenResponse">Successful
+   *     Token Response</a>
+   * @return TokenRoute
+   */
+  public TokenRoute withOkResponse(
+      @Nonnull TokenConfig accessTokenConfig,
+      @Nullable TokenConfig idTokenConfig,
+      @Nullable TokenConfig refreshTokenConfig,
+      @Nullable Integer expiresIn) {
+    this.statusCode = 200;
+    this.errorBody = null;
+    this.accessTokenConfig = accessTokenConfig;
+    this.idTokenConfig = idTokenConfig;
+    this.refreshTokenConfig = refreshTokenConfig;
+    this.expiresIn = expiresIn != null ? expiresIn.intValue() : 3600;
+    return this;
+  }
+
+  @Override
+  public void handle(@Nonnull final RoutingContext routingContext) {
+
+    String response = errorBody;
+    if (errorBody == null) {
+      JsonObject responseBody = new JsonObject();
+      UrlConfiguration requestConfiguration = routingContext.get(CTX_REQUEST_CONFIGURATION);
+      responseBody.put(
+          "access_token",
+          accessTokenConfig != null
+              ? tokenGenerator.getToken(accessTokenConfig, requestConfiguration)
+              : "");
+      responseBody.put(
+          "refresh_token",
+          refreshTokenConfig != null
+              ? tokenGenerator.getToken(refreshTokenConfig, requestConfiguration)
+              : "");
+      responseBody.put(
+          "id_token",
+          idTokenConfig != null
+              ? tokenGenerator.getToken(idTokenConfig, requestConfiguration)
+              : "");
+      responseBody.put("token_type", "Bearer");
+      responseBody.put("expires_in", expiresIn);
+      response = responseBody.encode();
+    }
+    routingContext
+        .response()
+        .setStatusCode(statusCode)
+        .putHeader("content-type", "application/json")
+        .end(response);
+  }
+
+
+}

--- a/mock/src/main/java/com/tngtech/keycloakmock/impl/handler/TokenRoute.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/impl/handler/TokenRoute.java
@@ -1,14 +1,15 @@
 package com.tngtech.keycloakmock.impl.handler;
 
 import static com.tngtech.keycloakmock.impl.handler.RequestUrlConfigurationHandler.CTX_REQUEST_CONFIGURATION;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+
 import com.tngtech.keycloakmock.api.TokenConfig;
 import com.tngtech.keycloakmock.impl.TokenGenerator;
 import com.tngtech.keycloakmock.impl.UrlConfiguration;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public class TokenRoute implements Handler<RoutingContext> {
   private TokenConfig accessTokenConfig;
@@ -96,6 +97,4 @@ public class TokenRoute implements Handler<RoutingContext> {
         .putHeader("content-type", "application/json")
         .end(response);
   }
-
-
 }

--- a/mock/src/test/java/com/tngtech/keycloakmock/impl/handler/TokenRouteTest.java
+++ b/mock/src/test/java/com/tngtech/keycloakmock/impl/handler/TokenRouteTest.java
@@ -5,6 +5,12 @@ import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
+
+import com.tngtech.keycloakmock.api.TokenConfig;
+import com.tngtech.keycloakmock.impl.TokenGenerator;
+import com.tngtech.keycloakmock.impl.UrlConfiguration;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.impl.jose.JWT;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.time.Instant;
@@ -15,11 +21,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import com.tngtech.keycloakmock.api.TokenConfig;
-import com.tngtech.keycloakmock.impl.TokenGenerator;
-import com.tngtech.keycloakmock.impl.UrlConfiguration;
-import io.vertx.core.json.JsonObject;
-import io.vertx.ext.auth.impl.jose.JWT;
 
 @ExtendWith(MockitoExtension.class)
 class TokenRouteTest extends HandlerTestBase {

--- a/mock/src/test/java/com/tngtech/keycloakmock/impl/handler/TokenRouteTest.java
+++ b/mock/src/test/java/com/tngtech/keycloakmock/impl/handler/TokenRouteTest.java
@@ -1,0 +1,146 @@
+package com.tngtech.keycloakmock.impl.handler;
+
+import static com.tngtech.keycloakmock.impl.handler.RequestUrlConfigurationHandler.CTX_REQUEST_CONFIGURATION;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.Instant;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import com.tngtech.keycloakmock.api.TokenConfig;
+import com.tngtech.keycloakmock.impl.TokenGenerator;
+import com.tngtech.keycloakmock.impl.UrlConfiguration;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.impl.jose.JWT;
+
+@ExtendWith(MockitoExtension.class)
+class TokenRouteTest extends HandlerTestBase {
+  @Mock private UrlConfiguration urlConfiguration;
+  private static final String ISSUER = "issuer";
+
+  @Test
+  void tokenSuccesful() throws Exception {
+    doReturn(serverResponse).when(serverResponse).setStatusCode(ArgumentMatchers.eq(200));
+    doReturn(urlConfiguration).when(routingContext).get(CTX_REQUEST_CONFIGURATION);
+    doReturn(new URI(ISSUER)).when(urlConfiguration).getIssuer();
+    //
+    final TokenGenerator tokenGenerator = new TokenGenerator();
+    TokenConfig accessTokenConfig =
+        TokenConfig.aTokenConfig()
+            .withSubject(RandomStringUtils.randomAlphabetic(10))
+            .withScope(RandomStringUtils.randomAlphabetic(15))
+            .withEmail(RandomStringUtils.randomAlphabetic(10) + "@mail.com")
+            .withRealmRole("realm-role")
+            .withAudience(RandomStringUtils.randomAlphabetic(15))
+            .withAuthorizedParty(RandomStringUtils.randomAlphabetic(20))
+            .withPreferredUsername(RandomStringUtils.randomAlphabetic(30))
+            .withFamilyName(RandomStringUtils.randomAlphabetic(25))
+            .withGivenName(RandomStringUtils.randomAlphabetic(15))
+            .withResourceRole("resource", "role")
+            .withClaim("claim1", false)
+            .withExpiration(Instant.now().plusSeconds(30))
+            .build();
+    TokenConfig refreshTokenConfig = TokenConfig.aTokenConfig().build();
+    TokenConfig idTokenConfig = TokenConfig.aTokenConfig().withEmail("email@email.com").build();
+    int expiresIn = RandomUtils.nextInt(1000, 60000);
+    TokenRoute tokenRoute =
+        new TokenRoute()
+            .withOkResponse(accessTokenConfig, idTokenConfig, refreshTokenConfig, expiresIn);
+
+    tokenRoute.handle(routingContext);
+    verify(serverResponse).end(captor.capture());
+    assertThatJson(captor.getValue())
+        .isObject()
+        .containsKeys("access_token", "refresh_token", "id_token", "token_type", "expires_in");
+    JsonObject responseBody = new JsonObject(captor.getValue());
+    assertEquals("Bearer", responseBody.getString("token_type"));
+    assertEquals(expiresIn, responseBody.getInteger("expires_in"));
+    assertEquals(
+        tokenGenerator.getToken(accessTokenConfig, urlConfiguration),
+        responseBody.getString("access_token"));
+    assertTokenData(JWT.parse(responseBody.getString("access_token")).encode(), accessTokenConfig);
+    assertEquals(
+        tokenGenerator.getToken(refreshTokenConfig, urlConfiguration),
+        responseBody.getString("refresh_token"));
+    assertEquals(
+        tokenGenerator.getToken(idTokenConfig, urlConfiguration),
+        responseBody.getString("id_token"));
+  }
+
+  /**
+   * The <b>assertTokenData</b> method returns {@link void}
+   *
+   * @param encode
+   * @param tokenConfig
+   */
+  private void assertTokenData(String encode, TokenConfig tokenConfig) {
+    assertThatJson(encode)
+        .and(
+            a -> a.node("header.kid").isEqualTo("keyId"),
+            a -> a.node("header.alg").isEqualTo("RS256"),
+            a ->
+                a.node("payload.aud")
+                    .isArray()
+                    .hasSize(1)
+                    .element(0)
+                    .isEqualTo(tokenConfig.getAudience().iterator().next()),
+            a -> a.node("payload.iat").isNumber().isNotNegative(),
+            a -> a.node("payload.auth_time").isNumber().isNotNegative(),
+            a ->
+                a.node("payload.exp")
+                    .isNumber()
+                    .isEqualByComparingTo(
+                        BigDecimal.valueOf(tokenConfig.getExpiration().getEpochSecond())),
+            a -> a.node("payload.scope").isString().isEqualTo(tokenConfig.getScope()),
+            a -> a.node("payload.azp").isString().isEqualTo(tokenConfig.getAuthorizedParty()),
+            a -> a.node("payload.sub").isString().isEqualTo(tokenConfig.getSubject()),
+            a ->
+                a.node("payload.preferred_username")
+                    .isString()
+                    .isEqualTo(tokenConfig.getPreferredUsername()),
+            a -> a.node("payload.family_name").isString().isEqualTo(tokenConfig.getFamilyName()),
+            a -> a.node("payload.given_name").isString().isEqualTo(tokenConfig.getGivenName()),
+            a -> a.node("payload.email").isString().isEqualTo(tokenConfig.getEmail()),
+            a ->
+                a.node("payload.realm_access.roles")
+                    .isArray()
+                    .hasSize(1)
+                    .element(0)
+                    .isEqualTo("realm-role"),
+            a ->
+                a.node("payload.resource_access.resource.roles")
+                    .isArray()
+                    .hasSize(1)
+                    .element(0)
+                    .isEqualTo("role"),
+            a -> a.node("payload.claim1").isBoolean().isFalse(),
+            a -> a.node("signatureBase").isString().isNotEmpty(),
+            a -> a.node("signature").isString().isNotEmpty());
+  }
+
+  @Test
+  void tokenError() throws Exception {
+    doReturn(serverResponse).when(serverResponse).setStatusCode(ArgumentMatchers.eq(404));
+
+    //
+    JsonObject jsonErrorObject = new JsonObject();
+    jsonErrorObject.put("error", "Error detail message");
+    TokenRoute tokenRoute = new TokenRoute().withErrorResponse(404, jsonErrorObject.encode());
+    tokenRoute.handle(routingContext);
+    verify(serverResponse).end(captor.capture());
+    assertThatJson(captor.getValue())
+        .isObject()
+        .containsOnlyKeys("error")
+        .hasFieldOrPropertyWithValue("error", "Error detail message");
+
+    verify(serverResponse).setStatusCode(404);
+  }
+}


### PR DESCRIPTION
Extends keycloak-mock handlers with token endpoint.

This endpoint is usefully to use in integration test, for example a application that need to get a access token (with roles) to consume another REST API or to easily test authorized/unauthorized requests.