### PR TITLE
Feature/desktop login

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,16 +3,34 @@ name: Java CI
 on: [ push, pull_request ]
 
 jobs:
+  check_commit_hooks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+      - name: Run pre-commit check
+        uses: pre-commit/action@v2.0.3
+
   build_java8:
 
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Check out
+        uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: '8'
       - name: Build with Gradle
         run: ./gradlew build
       - name: Run integration tests
@@ -23,11 +41,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - name: Check out
+        uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.11
+          distribution: 'adopt'
+          java-version: '11'
       - name: Build with Gradle
         run: ./gradlew build
       - name: Run sonar analysis

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: trailing-whitespace
+  - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
+    rev: v2.1.0
+    hooks:
+      - id: pretty-format-java
+        args: [ --autofix ]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,28 +2,34 @@
 
 Contributions are very welcome. The following will provide some helpful guidelines.
 
-
 ## How to build the project
 
 KeycloakMock requires JDK 8. To build the entire project run
+
 ```bash
 ./gradlew build
 ```
+
 ### Core functionality
 
-The main logic of the KeycloakMock is located in the [mock](mock) module. You can find functionality to generate user-defined access tokens
-and the mock endpoint to retrieve the public signature key here. To build, run
+The main logic of the KeycloakMock is located in the [mock](mock) module. It contains a lightweight
+mock implementation of the most commonly used REST APIs. In addition, it offers the functionality to
+generate user-defined access tokens which can be validated with the provided the public signature
+key endpoint. To build, run
+
 ```
 ./gradlew mock:build
 ```
 
 ### JUnit integration
 
-JUnit integration is provided in [mock-junit](mock-junit) (for JUnit 4) and [mock-junit5](mock-junit5).
+JUnit integration is provided in [mock-junit](mock-junit) (for JUnit 4)
+and [mock-junit5](mock-junit5).
 
 ### Standalone Mock
 
-[standalone](standalone) contains a lightweight standalone application with support for the OpenID Connect authorization code flow.
+[standalone](standalone) bundles the functionality of the mock module in a single JAR with no
+external dependencies.
 
 ## How to contribute
 
@@ -38,8 +44,8 @@ If you want to submit a contribution, please follow the following workflow:
 
 ### Commits
 
-Commit messages should be clear and fully elaborate the context and the reason of a change.
-If your commit refers to an issue, please post-fix it with the issue number, e.g.
+Commit messages should be clear and fully elaborate the context and the reason of a change. If your
+commit refers to an issue, please post-fix it with the issue number, e.g.
 
 ```
 Issue: #123
@@ -57,5 +63,7 @@ Resolves #123
 
 ### Formatting
 
-This project uses [google code style](https://github.com/google/styleguide). Running ```./gradlew googleJavaFormat``` 
-will automatically format java code correctly. See [here](https://github.com/google/google-java-format) for IDE integration.
+This project uses [google code style](https://github.com/google/styleguide).
+Running ```./gradlew googleJavaFormat```
+will automatically format java code correctly.
+See [here](https://github.com/google/google-java-format) for IDE integration.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,18 @@
 
 Contributions are very welcome. The following will provide some helpful guidelines.
 
+## Initial setup
+
+Please consider installing [pre-commit](https://pre-commit.com/) and registering it for this repo by
+runnning
+
+```bash
+pre-commit install
+```
+
+This will ensure correct file formatting by registering a pre-commit hook. If committing fails,
+check the unstaged changes and add them to the staging area, then commit.
+
 ## How to build the project
 
 KeycloakMock requires JDK 8. To build the entire project run
@@ -64,6 +76,6 @@ Resolves #123
 ### Formatting
 
 This project uses [google code style](https://github.com/google/styleguide).
-Running ```./gradlew googleJavaFormat```
+Running ```pre-commit run --all-files```
 will automatically format java code correctly.
 See [here](https://github.com/google/google-java-format) for IDE integration.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ public class Test {
   public static KeycloakMockRule mock = new KeycloakMockRule();
 
   // ...
-    
+
 }
 ```
 
@@ -84,7 +84,7 @@ class Test {
   static KeycloakMockExtension mock = new KeycloakMockExtension();
 
   // ...
-    
+
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ buildscript {
 plugins {
     id 'com.github.ben-manes.versions' version '0.39.0'
     id 'com.github.jk1.dependency-license-report' version '1.16' apply false
-    id 'com.github.sherter.google-java-format' version '0.9' apply false
     id 'com.google.cloud.tools.jib' version '3.1.1' apply false
     id 'org.sonarqube' version '3.3'
     id 'pl.allegro.tech.build.axion-release' version '1.13.2'
@@ -33,7 +32,6 @@ scmVersion {
 
 allprojects {
     apply plugin: 'idea'
-    apply plugin: 'com.github.sherter.google-java-format'
 
     repositories {
         mavenCentral()
@@ -41,13 +39,6 @@ allprojects {
 
     group = 'com.tngtech.keycloakmock'
     version = scmVersion.version
-
-    verifyGoogleJavaFormat.onlyIf {
-        JavaVersion.current().isJava11Compatible()
-    }
-    tasks.googleJavaFormat.onlyIf {
-        JavaVersion.current().isJava11Compatible()
-    }
 }
 
 ext {

--- a/build.gradle
+++ b/build.gradle
@@ -11,11 +11,11 @@ plugins {
     id 'com.github.jk1.dependency-license-report' version '1.16' apply false
     id 'com.google.cloud.tools.jib' version '3.1.1' apply false
     id 'org.sonarqube' version '3.3'
-    id 'pl.allegro.tech.build.axion-release' version '1.13.2'
+    id 'pl.allegro.tech.build.axion-release' version '1.13.3'
 }
 
 wrapper {
-    gradleVersion = '7.1'
+    gradleVersion = '7.1.1'
     distributionType = Wrapper.DistributionType.ALL
 }
 
@@ -47,10 +47,10 @@ ext {
     junit4_version = '4.13.2'
     junit5_version = '5.7.2'
     keycloak_version = '14.0.0'
-    mockito_version = '3.11.1'
+    mockito_version = '3.11.2'
     picocli_version = '4.6.1'
     restassured_version = '4.4.0'
-    slf4j_version = '1.7.30'
+    slf4j_version = '1.7.32'
     vertx_version = '4.1.0'
 
     license_name = 'The Apache License, Version 2.0'

--- a/example-backend/build.gradle
+++ b/example-backend/build.gradle
@@ -1,8 +1,6 @@
 buildscript {
     ext {
-        // it seems that Spring Boot 2.5+ is currently incompatible with the Keycloak Spring adapter
-        // see https://issues.redhat.com/browse/KEYCLOAK-18283 and https://github.com/spring-projects/spring-security/issues/9787
-        springBootVersion = '2.4.7'
+        springBootVersion = '2.5.3'
     }
     repositories {
         mavenCentral()
@@ -16,12 +14,6 @@ apply plugin: 'com.google.cloud.tools.jib'
 apply plugin: 'io.spring.dependency-management'
 apply plugin: 'java'
 apply plugin: 'org.springframework.boot'
-
-// spring boot's bill of materials pulls in junit5 in an outdated version, so we need to update it
-// see https://stackoverflow.com/questions/54598484/gradle-5-junit-bom-and-spring-boot-incorrect-versions
-ext['junit-jupiter.version'] = junit5_version
-// spring boot's bill of materials pulls in groovy v2, but rest assured needs groovy v3
-ext['groovy.version'] = '3.0.8'
 
 dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web:$springBootVersion"

--- a/example-frontend-react/package.json
+++ b/example-frontend-react/package.json
@@ -29,7 +29,7 @@
     "not op_mini all"
   ],
   "devDependencies": {
-    "cypress": "^7.5.0",
+    "cypress": "^8.0.0",
     "cypress-keycloak": "^1.7.0"
   }
 }

--- a/example-frontend-react/yarn
+++ b/example-frontend-react/yarn
@@ -1,4 +1,3 @@
 #!/bin/bash
 # gradle can not copy symbolic links, so the "binary" for yarn can not be used
 ./bin/nodejs/node/bin/node ./bin/yarn/yarn/lib/node_modules/yarn/bin/yarn.js "$@"
-

--- a/example-frontend-react/yarn.lock
+++ b/example-frontend-react/yarn.lock
@@ -2146,16 +2146,6 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
-"@cypress/listr-verbose-renderer@^0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@cypress/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz#a77492f4b11dcc7c446a34b3e28721afd33c642a"
-  integrity sha1-p3SS9LEdzHxEajSz4ochr9M8ZCo=
-  dependencies:
-    chalk "^1.1.3"
-    cli-cursor "^1.0.2"
-    date-fns "^1.27.2"
-    figures "^1.7.0"
-
 "@cypress/request@^2.88.5":
   version "2.88.5"
   resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.5.tgz#8d7ecd17b53a849cfd5ab06d5abe7d84976375d7"
@@ -3274,11 +3264,6 @@ ansi-regex@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
-ansi-styles@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
-  integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
-
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -4224,17 +4209,6 @@ chalk@2.4.2, chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
-  integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
-  dependencies:
-    ansi-styles "^2.2.1"
-    escape-string-regexp "^1.0.2"
-    has-ansi "^2.0.0"
-    strip-ansi "^3.0.0"
-    supports-color "^2.0.0"
-
 chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
@@ -4353,13 +4327,6 @@ clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
-
-cli-cursor@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
-  integrity sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=
-  dependencies:
-    restore-cursor "^1.0.1"
 
 cli-cursor@^3.1.0:
   version "3.1.0"
@@ -5021,12 +4988,11 @@ cypress-keycloak@^1.7.0:
   resolved "https://registry.yarnpkg.com/cypress-keycloak/-/cypress-keycloak-1.7.0.tgz#7556c297b12645405cd17d060d4fd6d1b73905ed"
   integrity sha512-sBlq7VUCTAUps/67mnDXg6rhVWS+PygspCGLfucmT/sQYanTVqmu374JCutNZGnNArOjmkaw0Rn80dC9dp9tJw==
 
-cypress@^7.5.0:
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-7.5.0.tgz#72dd342e3b45f54b63cd46819f38d126feff5954"
-  integrity sha512-tw3v6nrTJoEzT37+Nf6RK+DvdTfhMb8EJYskZx7oskZ+J9qQ1QHWA4dH8Eoe/Mr/wE47o+7PK6O9tgqhRy6IHg==
+cypress@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-8.0.0.tgz#bd68f4cff9ffb0c1176e9dd87d020cbdd0001ab8"
+  integrity sha512-Hhbc7FtbeCSg5Ui2zxXQLynk7IYGIygG8NqTauS4EtCWyp2k6s4g8P4KUZXwRbhuryN/+/dCd1kPtFbhBx8MuQ==
   dependencies:
-    "@cypress/listr-verbose-renderer" "^0.4.1"
     "@cypress/request" "^2.88.5"
     "@cypress/xvfb" "^1.2.4"
     "@types/node" "^14.14.31"
@@ -5038,15 +5004,18 @@ cypress@^7.5.0:
     cachedir "^2.3.0"
     chalk "^4.1.0"
     check-more-types "^2.24.0"
+    cli-cursor "^3.1.0"
     cli-table3 "~0.6.0"
     commander "^5.1.0"
     common-tags "^1.8.0"
     dayjs "^1.10.4"
-    debug "4.3.2"
+    debug "^4.3.2"
+    enquirer "^2.3.6"
     eventemitter2 "^6.4.3"
     execa "4.1.0"
     executable "^4.1.1"
     extract-zip "2.0.1"
+    figures "^3.2.0"
     fs-extra "^9.1.0"
     getos "^3.2.1"
     is-ci "^3.0.0"
@@ -5095,11 +5064,6 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-date-fns@^1.27.2:
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
-  integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
-
 dayjs@^1.10.4:
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.5.tgz#5600df4548fc2453b3f163ebb2abbe965ccfb986"
@@ -5111,13 +5075,6 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
-
-debug@4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
-  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
-  dependencies:
-    ms "2.1.2"
 
 debug@^3.1.0, debug@^3.2.6:
   version "3.2.7"
@@ -5144,6 +5101,13 @@ debug@^4.1.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
+
+debug@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
   dependencies:
     ms "2.1.2"
 
@@ -5540,7 +5504,7 @@ enhanced-resolve@^4.3.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
-enquirer@^2.3.5:
+enquirer@^2.3.5, enquirer@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
   integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
@@ -5665,7 +5629,7 @@ escape-string-regexp@2.0.0, escape-string-regexp@^2.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
@@ -6021,11 +5985,6 @@ executable@^4.1.1:
   dependencies:
     pify "^2.2.0"
 
-exit-hook@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
-  integrity sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=
-
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
@@ -6214,13 +6173,12 @@ figgy-pudding@^3.5.1:
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.2.tgz#b4eee8148abb01dcf1d1ac34367d59e12fa61d6e"
   integrity sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==
 
-figures@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
-  integrity sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=
+figures@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
+  integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
   dependencies:
     escape-string-regexp "^1.0.5"
-    object-assign "^4.1.0"
 
 file-entry-cache@^6.0.0:
   version "6.0.0"
@@ -6689,13 +6647,6 @@ harmony-reflect@^1.4.6:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/harmony-reflect/-/harmony-reflect-1.6.1.tgz#c108d4f2bb451efef7a37861fdbdae72c9bdefa9"
   integrity sha512-WJTeyp0JzGtHcuMsi7rw2VwtkvLa+JyfEKJCFyfcS0+CDkjQ5lHPu7zEhFZP+PDSRrEgXa5Ah0l1MbgbE41XjA==
-
-has-ansi@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
-  integrity sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
-  dependencies:
-    ansi-regex "^2.0.0"
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -9127,11 +9078,6 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-onetime@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
-  integrity sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=
-
 onetime@^5.1.0:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
@@ -10950,14 +10896,6 @@ resolve@^1.14.2, resolve@^1.17.0, resolve@^1.18.1:
     is-core-module "^2.1.0"
     path-parse "^1.0.6"
 
-restore-cursor@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
-  integrity sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=
-  dependencies:
-    exit-hook "^1.0.0"
-    onetime "^1.0.0"
-
 restore-cursor@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
@@ -11856,11 +11794,6 @@ stylehacks@^4.0.0:
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
 
-supports-color@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
-  integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
-
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -12418,15 +12351,7 @@ url-loader@4.1.1:
     mime-types "^2.1.27"
     schema-utils "^3.0.0"
 
-url-parse@^1.4.3:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.1.tgz#d5fa9890af8a5e1f274a2c98376510f6425f6e3b"
-  integrity sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==
-  dependencies:
-    querystringify "^2.1.1"
-    requires-port "^1.0.0"
-
-url-parse@^1.5.1:
+url-parse@^1.4.3, url-parse@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.1.tgz#d5fa9890af8a5e1f274a2c98376510f6425f6e3b"
   integrity sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==

--- a/example-integration-docker/build.gradle
+++ b/example-integration-docker/build.gradle
@@ -24,4 +24,3 @@ task e2e {
   dependsOn ':example-frontend-react:yarn_e2e'
   finalizedBy composeDown
 }
-

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/mock/src/main/java/com/tngtech/keycloakmock/api/KeycloakMock.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/api/KeycloakMock.java
@@ -4,6 +4,7 @@ import com.tngtech.keycloakmock.impl.TokenGenerator;
 import com.tngtech.keycloakmock.impl.UrlConfiguration;
 import com.tngtech.keycloakmock.impl.handler.AuthenticationRoute;
 import com.tngtech.keycloakmock.impl.handler.CommonHandler;
+import com.tngtech.keycloakmock.impl.handler.DelegationRoute;
 import com.tngtech.keycloakmock.impl.handler.FailureHandler;
 import com.tngtech.keycloakmock.impl.handler.IFrameRoute;
 import com.tngtech.keycloakmock.impl.handler.JwksRoute;
@@ -62,6 +63,7 @@ public class KeycloakMock {
   @Nonnull private final TokenRoute tokenRoute;
   @Nonnull private final LogoutRoute logoutRoute;
   @Nonnull private final IFrameRoute iframeRoute = new IFrameRoute();
+  @Nonnull private final DelegationRoute delegationRoute;
 
   @Nonnull
   private final ResourceFileHandler thirdPartyCookies1Route =
@@ -111,11 +113,12 @@ public class KeycloakMock {
         new TokenHelper(tokenGenerator, serverConfig.getResourcesToMapRolesTo());
     RedirectHelper redirectHelper = new RedirectHelper(tokenHelper);
     SessionRepository sessionRepository = new SessionRepository();
-    loginRoute =
-        new LoginRoute(sessionRepository, redirectHelper, FreeMarkerTemplateEngine.create(vertx));
+    FreeMarkerTemplateEngine engine = FreeMarkerTemplateEngine.create(vertx);
+    loginRoute = new LoginRoute(sessionRepository, redirectHelper, engine);
     authenticationRoute = new AuthenticationRoute(sessionRepository, redirectHelper);
     tokenRoute = new TokenRoute(sessionRepository, tokenHelper);
     logoutRoute = new LogoutRoute(sessionRepository, redirectHelper);
+    delegationRoute = new DelegationRoute(engine);
   }
 
   /**
@@ -188,6 +191,7 @@ public class KeycloakMock {
         .get(routing.getOpenIdPath("3p-cookies/step2.html").getPath())
         .handler(thirdPartyCookies2Route);
     router.get(routing.getEndSessionEndpoint().getPath()).handler(logoutRoute);
+    router.get(routing.getOpenIdPath("delegated").getPath()).handler(delegationRoute);
     router.route("/auth/js/keycloak.js").handler(keycloakJsRoute);
     return router;
   }

--- a/mock/src/main/java/com/tngtech/keycloakmock/api/KeycloakMock.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/api/KeycloakMock.java
@@ -10,6 +10,7 @@ import com.tngtech.keycloakmock.impl.handler.IFrameRoute;
 import com.tngtech.keycloakmock.impl.handler.JwksRoute;
 import com.tngtech.keycloakmock.impl.handler.LoginRoute;
 import com.tngtech.keycloakmock.impl.handler.LogoutRoute;
+import com.tngtech.keycloakmock.impl.handler.OutOfBandLoginRoute;
 import com.tngtech.keycloakmock.impl.handler.RequestUrlConfigurationHandler;
 import com.tngtech.keycloakmock.impl.handler.ResourceFileHandler;
 import com.tngtech.keycloakmock.impl.handler.TokenRoute;
@@ -64,6 +65,7 @@ public class KeycloakMock {
   @Nonnull private final LogoutRoute logoutRoute;
   @Nonnull private final IFrameRoute iframeRoute = new IFrameRoute();
   @Nonnull private final DelegationRoute delegationRoute;
+  @Nonnull private final OutOfBandLoginRoute outOfBandLoginRoute;
 
   @Nonnull
   private final ResourceFileHandler thirdPartyCookies1Route =
@@ -119,6 +121,7 @@ public class KeycloakMock {
     tokenRoute = new TokenRoute(sessionRepository, tokenHelper);
     logoutRoute = new LogoutRoute(sessionRepository, redirectHelper);
     delegationRoute = new DelegationRoute(engine);
+    outOfBandLoginRoute = new OutOfBandLoginRoute(engine);
   }
 
   /**
@@ -192,6 +195,7 @@ public class KeycloakMock {
         .handler(thirdPartyCookies2Route);
     router.get(routing.getEndSessionEndpoint().getPath()).handler(logoutRoute);
     router.get(routing.getOpenIdPath("delegated").getPath()).handler(delegationRoute);
+    router.get(routing.getOutOfBandLoginLoginEndpoint().getPath()).handler(outOfBandLoginRoute);
     router.route("/auth/js/keycloak.js").handler(keycloakJsRoute);
     return router;
   }

--- a/mock/src/main/java/com/tngtech/keycloakmock/api/TokenConfig.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/api/TokenConfig.java
@@ -342,7 +342,8 @@ public class TokenConfig {
         throw new IllegalArgumentException(
             "The issuer '"
                 + issuer
-                + "' did not conform to the expected format 'http[s]://$HOSTNAME[:port]/auth/realms/$REALM'.");
+                + "' did not conform to the expected format"
+                + " 'http[s]://$HOSTNAME[:port]/auth/realms/$REALM'.");
       }
       return matcher.group(1);
     }

--- a/mock/src/main/java/com/tngtech/keycloakmock/impl/UrlConfiguration.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/impl/UrlConfiguration.java
@@ -10,6 +10,7 @@ import javax.annotation.Nullable;
 public class UrlConfiguration {
   private static final String ISSUER_PATH = "/auth/realms/";
   private static final String AUTHENTICATION_CALLBACK_PATH = "authenticate/";
+  private static final String OUT_OF_BAND_PATH = "oob";
   private static final String ISSUER_OPEN_ID_PATH = "protocol/openid-connect/";
   private static final String OPEN_ID_TOKEN_PATH = "token";
   private static final String OPEN_ID_JWKS_PATH = "certs";
@@ -75,6 +76,11 @@ public class UrlConfiguration {
   @Nonnull
   public URI getAuthenticationCallbackEndpoint(@Nonnull final String sessionId) {
     return getIssuerPath().resolve(AUTHENTICATION_CALLBACK_PATH + sessionId);
+  }
+
+  @Nonnull
+  public URI getOutOfBandLoginLoginEndpoint() {
+    return getIssuerPath().resolve(OUT_OF_BAND_PATH);
   }
 
   @Nonnull

--- a/mock/src/main/java/com/tngtech/keycloakmock/impl/handler/DelegationRoute.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/impl/handler/DelegationRoute.java
@@ -1,0 +1,42 @@
+package com.tngtech.keycloakmock.impl.handler;
+
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.common.template.TemplateEngine;
+import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DelegationRoute implements Handler<RoutingContext> {
+  private static final Logger LOG = LoggerFactory.getLogger(DelegationRoute.class);
+  private static final String HEADER = "header";
+  private static final String BODY = "body";
+
+  @Nonnull private final TemplateEngine engine;
+
+  public DelegationRoute(@Nonnull TemplateEngine engine) {
+    this.engine = engine;
+  }
+
+  @Override
+  public void handle(RoutingContext routingContext) {
+    if ("true".equals(routingContext.queryParams().get("error"))) {
+      routingContext.put(HEADER, "Delegation failed");
+      routingContext.put(
+          BODY, "You need to check the output of your client to see what went wrong.");
+    } else {
+      routingContext.put(HEADER, "Delegation successful");
+      routingContext.put(BODY, "You may now close this browser window.");
+    }
+    engine
+        .render(routingContext.data(), "delegation.ftl")
+        .onSuccess(
+            b -> routingContext.response().putHeader(HttpHeaders.CONTENT_TYPE, "text/html").end(b))
+        .onFailure(
+            t -> {
+              LOG.error("Unable to render login page", t);
+              routingContext.fail(t);
+            });
+  }
+}

--- a/mock/src/main/java/com/tngtech/keycloakmock/impl/handler/OutOfBandLoginRoute.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/impl/handler/OutOfBandLoginRoute.java
@@ -1,0 +1,36 @@
+package com.tngtech.keycloakmock.impl.handler;
+
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.common.template.TemplateEngine;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OutOfBandLoginRoute implements Handler<RoutingContext> {
+  private static final Logger LOG = LoggerFactory.getLogger(OutOfBandLoginRoute.class);
+  private static final String CODE = "code";
+
+  @Nonnull private final TemplateEngine engine;
+
+  public OutOfBandLoginRoute(@Nonnull TemplateEngine engine) {
+    this.engine = engine;
+  }
+
+  @Override
+  public void handle(RoutingContext routingContext) {
+    routingContext.put(
+        CODE, Optional.ofNullable(routingContext.queryParams().get(CODE)).orElse("invalid"));
+    engine
+        .render(routingContext.data(), "oob.ftl")
+        .onSuccess(
+            b -> routingContext.response().putHeader(HttpHeaders.CONTENT_TYPE, "text/html").end(b))
+        .onFailure(
+            t -> {
+              LOG.error("Unable to render oob page", t);
+              routingContext.fail(t);
+            });
+  }
+}

--- a/mock/src/main/java/com/tngtech/keycloakmock/impl/session/PersistentSession.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/impl/session/PersistentSession.java
@@ -10,7 +10,7 @@ public class PersistentSession implements Session {
   @Nonnull private final String sessionId;
   @Nonnull private final String username;
   @Nonnull private final List<String> roles;
-  @Nonnull private final String state;
+  @Nullable private final String state;
   @Nonnull private final String redirectUri;
   @Nonnull private final String responseType;
   @Nullable private final String responseMode;
@@ -53,7 +53,7 @@ public class PersistentSession implements Session {
     return roles;
   }
 
-  @Nonnull
+  @Nullable
   public String getState() {
     return state;
   }

--- a/mock/src/main/java/com/tngtech/keycloakmock/impl/session/SessionRequest.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/impl/session/SessionRequest.java
@@ -11,13 +11,13 @@ public class SessionRequest {
   @Nullable private final String responseMode;
   @Nonnull private final String responseType;
   @Nonnull private final String redirectUri;
-  @Nonnull private final String state;
+  @Nullable private final String state;
   @Nullable private final String nonce;
 
   private SessionRequest(Builder builder) {
     clientId = Objects.requireNonNull(builder.clientId);
     sessionId = Objects.requireNonNull(builder.sessionId);
-    state = Objects.requireNonNull(builder.state);
+    state = builder.state;
     redirectUri = Objects.requireNonNull(builder.redirectUri);
     responseType = Objects.requireNonNull(builder.responseType);
     responseMode = builder.responseMode;
@@ -49,7 +49,7 @@ public class SessionRequest {
     return redirectUri;
   }
 
-  @Nonnull
+  @Nullable
   public String getState() {
     return state;
   }
@@ -66,7 +66,7 @@ public class SessionRequest {
   public static class Builder {
     private String clientId;
     private String sessionId;
-    private String state;
+    @Nullable private String state;
     private String redirectUri;
     private String responseType;
     @Nullable private String responseMode;
@@ -77,8 +77,8 @@ public class SessionRequest {
       return this;
     }
 
-    public Builder setState(@Nonnull String state) {
-      this.state = Objects.requireNonNull(state);
+    public Builder setState(@Nullable String state) {
+      this.state = state;
       return this;
     }
 

--- a/mock/src/main/resources/delegation.ftl
+++ b/mock/src/main/resources/delegation.ftl
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Login result</title>
+</head>
+<body>
+<h1>${header}</h1>
+<p>${body}</p>
+</body>
+</html>

--- a/mock/src/main/resources/oob.ftl
+++ b/mock/src/main/resources/oob.ftl
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>${code}</title>
+</head>
+<body>
+<h1>Authorization code</h1>
+<p>${code}</p>
+</body>
+</html>

--- a/mock/src/test/java/com/tngtech/keycloakmock/impl/helper/RedirectHelperTest.java
+++ b/mock/src/test/java/com/tngtech/keycloakmock/impl/helper/RedirectHelperTest.java
@@ -65,51 +65,51 @@ class RedirectHelperTest {
         Arguments.of(
             ResponseType.CODE,
             null,
-            "https://localhost:1234/gohere?state=state123&session_state=session123&code=session123"),
+            "https://localhost:1234/gohere?session_state=session123&state=state123&code=session123"),
         Arguments.of(
             ResponseType.CODE,
             ResponseMode.FRAGMENT,
-            "https://localhost:1234/gohere#state=state123&session_state=session123&code=session123"),
+            "https://localhost:1234/gohere#session_state=session123&state=state123&code=session123"),
         Arguments.of(
             ResponseType.CODE,
             ResponseMode.QUERY,
-            "https://localhost:1234/gohere?state=state123&session_state=session123&code=session123"),
+            "https://localhost:1234/gohere?session_state=session123&state=state123&code=session123"),
         Arguments.of(
             ResponseType.ID_TOKEN,
             null,
-            "https://localhost:1234/gohere#state=state123&session_state=session123&id_token=tokenstring"),
+            "https://localhost:1234/gohere#session_state=session123&state=state123&id_token=tokenstring"),
         Arguments.of(
             ResponseType.ID_TOKEN,
             ResponseMode.FRAGMENT,
-            "https://localhost:1234/gohere#state=state123&session_state=session123&id_token=tokenstring"),
+            "https://localhost:1234/gohere#session_state=session123&state=state123&id_token=tokenstring"),
         Arguments.of(
             ResponseType.ID_TOKEN,
             ResponseMode.QUERY,
-            "https://localhost:1234/gohere#state=state123&session_state=session123&id_token=tokenstring"),
+            "https://localhost:1234/gohere#session_state=session123&state=state123&id_token=tokenstring"),
         Arguments.of(
             ResponseType.ID_TOKEN_PLUS_TOKEN,
             null,
-            "https://localhost:1234/gohere#state=state123&session_state=session123&id_token=tokenstring&access_token=tokenstring&token_type=bearer"),
+            "https://localhost:1234/gohere#session_state=session123&state=state123&id_token=tokenstring&access_token=tokenstring&token_type=bearer"),
         Arguments.of(
             ResponseType.ID_TOKEN_PLUS_TOKEN,
             ResponseMode.FRAGMENT,
-            "https://localhost:1234/gohere#state=state123&session_state=session123&id_token=tokenstring&access_token=tokenstring&token_type=bearer"),
+            "https://localhost:1234/gohere#session_state=session123&state=state123&id_token=tokenstring&access_token=tokenstring&token_type=bearer"),
         Arguments.of(
             ResponseType.ID_TOKEN_PLUS_TOKEN,
             ResponseMode.QUERY,
-            "https://localhost:1234/gohere#state=state123&session_state=session123&id_token=tokenstring&access_token=tokenstring&token_type=bearer"),
+            "https://localhost:1234/gohere#session_state=session123&state=state123&id_token=tokenstring&access_token=tokenstring&token_type=bearer"),
         Arguments.of(
             ResponseType.NONE,
             null,
-            "https://localhost:1234/gohere?state=state123&session_state=session123"),
+            "https://localhost:1234/gohere?session_state=session123&state=state123"),
         Arguments.of(
             ResponseType.NONE,
             ResponseMode.FRAGMENT,
-            "https://localhost:1234/gohere#state=state123&session_state=session123"),
+            "https://localhost:1234/gohere#session_state=session123&state=state123"),
         Arguments.of(
             ResponseType.NONE,
             ResponseMode.QUERY,
-            "https://localhost:1234/gohere?state=state123&session_state=session123"));
+            "https://localhost:1234/gohere?session_state=session123&state=state123"));
   }
 
   @ParameterizedTest(name = "correct redirect for ''{0}'' and ''{1}''")
@@ -130,6 +130,22 @@ class RedirectHelperTest {
     String redirectLocation = uut.getRedirectLocation(session, urlConfiguration);
 
     assertThat(redirectLocation).isEqualTo(expectedRedirectUrl);
+  }
+
+  @Test
+  void oob_redirect_location_is_generated_correctly() {
+    doReturn(SESSION_ID).when(session).getSessionId();
+    doReturn(STATE).when(session).getState();
+    doReturn("urn:ietf:wg:oauth:2.0:oob").when(session).getRedirectUri();
+    doReturn(ResponseType.CODE.toString()).when(session).getResponseType();
+    URI oobUri = URI.create("file:///oob-dummy");
+    doReturn(oobUri).when(urlConfiguration).getOutOfBandLoginLoginEndpoint();
+    doReturn(TOKEN).when(tokenHelper).getToken(session, urlConfiguration);
+
+    String redirectLocation = uut.getRedirectLocation(session, urlConfiguration);
+
+    assertThat(redirectLocation)
+        .isEqualTo("file:///oob-dummy?session_state=session123&state=state123&code=session123");
   }
 
   @Test

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,4 +7,3 @@ include 'standalone'
 include 'example-backend'
 include 'example-frontend-react'
 include 'example-integration-docker'
-


### PR DESCRIPTION
This PR adds support for desktop client login (see https://www.keycloak.org/docs/latest/securing_apps/#_installed_adapter) using browser flow (the app opens a browser with the login dialog of the mock and opens a webserver that listens to the localhost redirect URL) and manual flow (the user is presented with a link to the login page with special redirect URI "urn:ietf:wg:oauth:2.0:oob", then gets redirected to a page containing the authorization code which manually needs to be entered in the application).

The custom "command line" flow of Keycloak (the client sets a display_mode parameter and gets a 401 response with a specification of the necessary input fields to present and a callback URL to which to send this input via form POST) is not implemented yet as it is deemed too much effort for now (see https://github.com/keycloak/keycloak/blob/master/server-spi-private/src/main/java/org/keycloak/authentication/ConsoleDisplayMode.java).