### PR TITLE
Update ReadMe to avoid deprecated method in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ import com.tngtech.keycloakmock.api.KeycloakMock;
 
 class Test {
 
-  KeycloakMock mock = new KeycloakMock(aServerConfig().withPort(8000).withRealm("master").build());
+  KeycloakMock mock = new KeycloakMock(aServerConfig().withPort(8000).withDefaultRealm("master").build());
 
   static {
     mock.start();


### PR DESCRIPTION
Small Improvement in ReadMe documentation to replace withRealm wich is deprecated by withDefaultRealm