### PR TITLE
support confidential clients that authenticate using form fields

### DIFF
--- a/mock/src/main/java/com/tngtech/keycloakmock/impl/handler/TokenRoute.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/impl/handler/TokenRoute.java
@@ -118,15 +118,22 @@ public class TokenRoute implements Handler<RoutingContext> {
   }
 
   private void handleClientCredentialsFlow(RoutingContext routingContext) {
+    String clientId = routingContext.request().getFormAttribute("client_id");
+    String password = routingContext.request().getFormAttribute("client_secret");
+    boolean formBasedAuth = clientId != null && !clientId.isEmpty() && password != null && !password.isEmpty();
     final User user = routingContext.user();
-    if (user == null) {
+    if (user == null && !formBasedAuth) {
       routingContext.fail(401);
       return;
     }
 
-    final String clientId = routingContext.user().get("username");
-    // Password is a list of roles
-    final String password = routingContext.user().get("password");
+    //if not form based, try using user (BASIC auth or custom)
+    if (!formBasedAuth) {
+      clientId = routingContext.user().get("username");
+      // Password is a list of roles
+      password = routingContext.user().get("password");
+    }
+
     if (clientId == null || clientId.isEmpty()) {
       routingContext.fail(400);
       return;

--- a/mock/src/main/java/com/tngtech/keycloakmock/impl/handler/TokenRoute.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/impl/handler/TokenRoute.java
@@ -120,14 +120,15 @@ public class TokenRoute implements Handler<RoutingContext> {
   private void handleClientCredentialsFlow(RoutingContext routingContext) {
     String clientId = routingContext.request().getFormAttribute("client_id");
     String password = routingContext.request().getFormAttribute("client_secret");
-    boolean formBasedAuth = clientId != null && !clientId.isEmpty() && password != null && !password.isEmpty();
+    boolean formBasedAuth =
+        clientId != null && !clientId.isEmpty() && password != null && !password.isEmpty();
     final User user = routingContext.user();
     if (user == null && !formBasedAuth) {
       routingContext.fail(401);
       return;
     }
 
-    //if not form based, try using user (BASIC auth or custom)
+    // if not form based, try using user (BASIC auth or custom)
     if (!formBasedAuth) {
       clientId = routingContext.user().get("username");
       // Password is a list of roles

--- a/mock/src/test/java/com/tngtech/keycloakmock/api/KeycloakMockIntegrationTest.java
+++ b/mock/src/test/java/com/tngtech/keycloakmock/api/KeycloakMockIntegrationTest.java
@@ -594,6 +594,34 @@ class KeycloakMockIntegrationTest {
     assertThat(tokenConfig.getAudience()).containsExactly("client");
   }
 
+  @Test
+  void mock_server_login_with_client_credentials_flow_using_form_works() {
+    keycloakMock = new KeycloakMock();
+    keycloakMock.start();
+
+    ExtractableResponse<Response> extractableResponse =
+        RestAssured.given()
+            .when()
+            .formParam("grant_type", "client_credentials")
+            .formParam("client_id", "client")
+            .formParam("client_secret", "role1,role2,role3")
+            .post(TOKEN_ENDPOINT_URL)
+            .then()
+            .assertThat()
+            .statusCode(200)
+            .extract();
+
+    String accessToken = extractableResponse.body().jsonPath().getString("access_token");
+
+    Jws<Claims> jwt = jwtParser.parseClaimsJws(accessToken);
+    assertThat(jwt.getBody().getIssuer()).isEqualTo("http://localhost:8000/auth/realms/realm");
+    TokenConfig tokenConfig = TokenConfig.aTokenConfig().withSourceToken(accessToken).build();
+    assertThat(tokenConfig.getPreferredUsername()).isEqualTo("client");
+    assertThat(tokenConfig.getRealmAccess().getRoles())
+        .containsExactlyInAnyOrder("role1", "role2", "role3");
+    assertThat(tokenConfig.getAudience()).containsExactly("client");
+  }
+
   private void getTokenAndValidateAndReturnSessionCookie() {}
 
   private static class ClientRequest {


### PR DESCRIPTION
Fixes https://github.com/TNG/keycloak-mock/issues/98

This will allow confidential clients that use a form based approach instead of only using Basic auth.