### PR TITLE
Can now supply email as login username and names will be derived.

### DIFF
--- a/mock/src/main/java/com/tngtech/keycloakmock/impl/helper/TokenHelper.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/impl/helper/TokenHelper.java
@@ -2,17 +2,21 @@ package com.tngtech.keycloakmock.impl.helper;
 
 import static com.tngtech.keycloakmock.api.TokenConfig.aTokenConfig;
 
-import com.tngtech.keycloakmock.api.TokenConfig.Builder;
-import com.tngtech.keycloakmock.impl.TokenGenerator;
-import com.tngtech.keycloakmock.impl.UrlConfiguration;
-import com.tngtech.keycloakmock.impl.session.Session;
 import java.util.List;
 import java.util.Map;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.tngtech.keycloakmock.api.TokenConfig.Builder;
+import com.tngtech.keycloakmock.impl.TokenGenerator;
+import com.tngtech.keycloakmock.impl.UrlConfiguration;
+import com.tngtech.keycloakmock.impl.session.Session;
 
 @Singleton
 public class TokenHelper {
@@ -38,13 +42,11 @@ public class TokenHelper {
             .withAuthorizedParty(session.getClientId())
             // at the moment, there is no explicit way of setting an audience
             .withAudience(session.getClientId())
-            .withSubject(session.getUsername())
-            .withPreferredUsername(session.getUsername())
-            .withFamilyName(session.getUsername())
             .withClaim(SESSION_STATE, session.getSessionId())
             // we currently don't do proper authorization anyway, so we can just act as if we were
             // compliant to ISO/IEC 29115 level 1 (see KEYCLOAK-3223 / KEYCLOAK-3314)
             .withAuthenticationContextClassReference("1");
+    resolveUsername(builder, session.getUsername());
     if (session.getNonce() != null) {
       builder.withClaim(NONCE, session.getNonce());
     }
@@ -63,4 +65,48 @@ public class TokenHelper {
   public Map<String, Object> parseToken(@Nonnull String token) {
     return tokenGenerator.parseToken(token);
   }
+
+  // To get an email, given name, and family name, use this email pattern as
+  // the username when logging in:
+  //
+  //    firstname.lastname@somewhere.com
+  //
+  // It will result in these being set:
+  //
+  //    subject:           firstname.lastname
+  //    preferredUsername: firstname.lastname
+  //    givenName:         Firstname             // Capitalized
+  //    familyName:        Lastname              // Capitalized
+  //    email:             firstname.lastname@somewhere.com
+  //
+  // If the login user name is not an email, the provided value will be stored
+  // as is everywhere, except for email and given name, which won't be set.
+  private static void resolveUsername(Builder builder, String formUsername) {
+    String cleanFormUsername = StringUtils.trimToNull(formUsername);
+    if (cleanFormUsername == null) {
+      return;
+    }
+
+    String username = StringUtils.substringBefore(cleanFormUsername, "@");
+    builder.withSubject(username);
+    builder.withPreferredUsername(username);
+
+    // at this point if username is different than login user name,
+    // we assume the supplied login user name is an email and we can
+    // derive names
+    if (!username.equals(cleanFormUsername)) {
+        builder.withEmail(cleanFormUsername);
+        builder.withGivenName(cap(StringUtils.substringBefore(username, ".")));
+        builder.withFamilyName(cap(StringUtils.substringAfter(username, ".")));
+    } else {
+        builder.withFamilyName(username);
+    }
+  }
+  private static String cap(String str) {
+    if (str.isEmpty()) {
+      return str;
+    }
+    return str.substring(0, 1).toUpperCase() + str.substring(1);
+  }
 }
+


### PR DESCRIPTION
Thanks for this great testing library. A real time saver for local development/testing.  

I have a case where I use the mock server for local development and I need the user email.  Since there is no way to set it via login (where it would be the most convenient), I figured we could add the ability to provide email as username.

The current behavior will remain unchanged, except when an email is provided, then we set it as the user email, and derive the username, given/family names from it.  

For example, let's assume one provides an email in the username field of the login form with the following format:
```
firstname.lastname@somewhere.com
```

Then it will result in the following claims being set:

```
subject:           firstname.lastname
preferredUsername: firstname.lastname
givenName:         Firstname             // Capitalized
familyName:        Lastname              // Capitalized
email:             firstname.lastname@somewhere.com
```
If the login user name is not an email, the provided value will be stored as is everywhere, except for email and given name, which won't be set (current behavior).

If you like the idea, feel free to adapt to your liking.