### PR TITLE
support Keycloak 18's logout/?post_logout_redirect_uri

### DIFF
--- a/mock/src/main/java/com/tngtech/keycloakmock/impl/handler/LogoutRoute.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/impl/handler/LogoutRoute.java
@@ -14,10 +14,20 @@ import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+/**
+ * @see <a
+ *     href="https://github.com/keycloak/keycloak-documentation/blob/main/securing_apps/topics/oidc/java/logout.adoc">Logout</a>
+ */
 @Singleton
 public class LogoutRoute implements Handler<RoutingContext> {
 
-  private static final String REDIRECT_URI = "redirect_uri";
+  /**
+   * <a href="https://github.com/keycloak/keycloak/pull/10887/">Before Keycloak 18</a>, the logout
+   * endpoint had used the {@value #LEGACY_REDIRECT_URI} query parameter.
+   */
+  private static final String LEGACY_REDIRECT_URI = "redirect_uri";
+
+  private static final String POST_LOGOUT_REDIRECT_URI = "post_logout_redirect_uri";
   @Nonnull private final SessionRepository sessionRepository;
   @Nonnull private final RedirectHelper redirectHelper;
 
@@ -30,7 +40,10 @@ public class LogoutRoute implements Handler<RoutingContext> {
 
   @Override
   public void handle(@Nonnull RoutingContext routingContext) {
-    String redirectUri = routingContext.queryParams().get(REDIRECT_URI);
+    String redirectUri = routingContext.queryParams().get(POST_LOGOUT_REDIRECT_URI);
+    if (redirectUri == null) { // for backwards compatibility:
+      redirectUri = routingContext.queryParams().get(LEGACY_REDIRECT_URI);
+    }
     UrlConfiguration requestConfiguration = routingContext.get(CTX_REQUEST_CONFIGURATION);
     invalidateSession(routingContext);
     routingContext

--- a/mock/src/main/java/com/tngtech/keycloakmock/impl/handler/LogoutRoute.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/impl/handler/LogoutRoute.java
@@ -15,8 +15,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 /**
- * @see <a
- *     href="https://github.com/keycloak/keycloak-documentation/blob/main/securing_apps/topics/oidc/java/logout.adoc">Logout</a>
+ * @see <a href="https://www.keycloak.org/docs/latest/securing_apps/index.html#logout">Logout</a>
  */
 @Singleton
 public class LogoutRoute implements Handler<RoutingContext> {

--- a/mock/src/test/java/com/tngtech/keycloakmock/api/KeycloakMockIntegrationTest.java
+++ b/mock/src/test/java/com/tngtech/keycloakmock/api/KeycloakMockIntegrationTest.java
@@ -496,7 +496,7 @@ class KeycloakMockIntegrationTest {
         .config(config().redirect(redirectConfig().followRedirects(false)))
         .when()
         .get(
-            "http://localhost:8000/auth/realms/realm/protocol/openid-connect/logout?redirect_uri=redirect_uri")
+            "http://localhost:8000/auth/realms/realm/protocol/openid-connect/logout?post_logout_redirect_uri=redirect_uri")
         .then()
         .assertThat()
         .statusCode(302)


### PR DESCRIPTION
Since https://github.com/keycloak/keycloak/pull/10887, Keycloak is compliant with "OpenID Connect RP-Initiated Logout" and uses the `post_logout_redirect_uri` (instead of `redirect_url`) parameter at the logout endpoint.