### PR TITLE
Added support for disabling /auth context path. Resolves #126

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ class Test {
     mock.stop();
   }
 
+  void quarkusKeycloakMocks() {
+    // to mock Keycloak without context path (v18.0.0+)
+    KeycloakMock mockNoContextPath = new KeycloakMock(aServerConfig().withNoContextPath().build());
+    // or to use custom one
+    KeycloakMock mockCustomContextPath = new KeycloakMock(aServerConfig().withContextPath("/context-path").build());
+    // if context path is not provided, '/auth' will be used as default due to backward compatibility reasons
+    KeycloakMock mockDefaultContextPath = new KeycloakMock(aServerConfig().build());
+    // ...
+  }
 }
 ```
 

--- a/mock/src/main/java/com/tngtech/keycloakmock/api/ServerConfig.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/api/ServerConfig.java
@@ -284,16 +284,14 @@ public final class ServerConfig {
     /**
      * Set context path.
      *
-     * <p>Before quarkus based Keycloak distribution /auth prefix was obligatory.
-     * Now /auth prefix is removed and can be enabled/overridden in configuration to keep backward compatibility.</p>
-     *
-     * Default value is '/auth'
-     * To disable context path use {@link #withNoContextPath()} method.
+     * <p>Before quarkus based Keycloak distribution /auth prefix was obligatory. Now /auth prefix
+     * is removed and can be enabled/overridden in configuration to keep backward compatibility.
+     * Default value is '/auth' To disable context path use {@link #withNoContextPath()} method.
      *
      * @see <a href="https://www.keycloak.org/server/all-config#category-hostname">hostname-path</a>
-     * @see <a href="https://www.keycloak.org/migration/migrating-to-quarkus#_default_context_path_changed">
-     *     Default context path changed</a>
-     *
+     * @see <a
+     *     href="https://www.keycloak.org/migration/migrating-to-quarkus#_default_context_path_changed">Default
+     *     context path changed</a>
      * @param contextPath context path to use
      * @return builder
      */
@@ -307,7 +305,6 @@ public final class ServerConfig {
      * Disabling context path.
      *
      * @see #withContextPath(String)
-     *
      * @return builder
      */
     @Nonnull

--- a/mock/src/main/java/com/tngtech/keycloakmock/api/ServerConfig.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/api/ServerConfig.java
@@ -13,6 +13,7 @@ import javax.annotation.Nonnull;
 public final class ServerConfig {
 
   private static final String DEFAULT_HOSTNAME = "localhost";
+  private static final String DEFAULT_CONTEXT_PATH = "/auth";
   private static final int DEFAULT_PORT = 8000;
   private static final String DEFAULT_REALM = "master";
   private static final String DEFAULT_SCOPE = "openid";
@@ -20,6 +21,7 @@ public final class ServerConfig {
   private final int port;
   @Nonnull private final Protocol protocol;
   @Nonnull private final String defaultHostname;
+  @Nonnull private final String contextPath;
   @Nonnull private final String defaultRealm;
   @Nonnull private final List<String> resourcesToMapRolesTo;
   @Nonnull private final Set<String> defaultScopes;
@@ -28,6 +30,7 @@ public final class ServerConfig {
     this.port = builder.port;
     this.protocol = builder.protocol;
     this.defaultHostname = builder.defaultHostname;
+    this.contextPath = builder.contextPath;
     this.defaultRealm = builder.defaultRealm;
     this.resourcesToMapRolesTo = builder.resourcesToMapRolesTo;
     this.defaultScopes = builder.defaultScopes;
@@ -102,6 +105,18 @@ public final class ServerConfig {
   }
 
   /**
+   * Keycloak context path.
+   *
+   * @return context path
+   * @see Builder#withContextPath(String)
+   * @see Builder#withNoContextPath()
+   */
+  @Nonnull
+  public String getContextPath() {
+    return contextPath;
+  }
+
+  /**
    * The default realm used in issuer claim.
    *
    * @return default realm
@@ -143,6 +158,7 @@ public final class ServerConfig {
     private int port = DEFAULT_PORT;
     @Nonnull private Protocol protocol = Protocol.HTTP;
     @Nonnull private String defaultHostname = DEFAULT_HOSTNAME;
+    @Nonnull private String contextPath = DEFAULT_CONTEXT_PATH;
     @Nonnull private String defaultRealm = DEFAULT_REALM;
     @Nonnull private final List<String> resourcesToMapRolesTo = new ArrayList<>();
     @Nonnull private final Set<String> defaultScopes = new HashSet<>();
@@ -262,6 +278,41 @@ public final class ServerConfig {
     @Nonnull
     public Builder withResourcesToMapRolesTo(@Nonnull List<String> resources) {
       resourcesToMapRolesTo.addAll(resources);
+      return this;
+    }
+
+    /**
+     * Set context path.
+     *
+     * <p>Before quarkus based Keycloak distribution /auth prefix was obligatory.
+     * Now /auth prefix is removed and can be enabled/overridden in configuration to keep backward compatibility.</p>
+     *
+     * Default value is '/auth'
+     * To disable context path use {@link #withNoContextPath()} method.
+     *
+     * @see <a href="https://www.keycloak.org/server/all-config#category-hostname">hostname-path</a>
+     * @see <a href="https://www.keycloak.org/migration/migrating-to-quarkus#_default_context_path_changed">
+     *     Default context path changed</a>
+     *
+     * @param contextPath context path to use
+     * @return builder
+     */
+    @Nonnull
+    public Builder withContextPath(@Nonnull String contextPath) {
+      this.contextPath = contextPath;
+      return this;
+    }
+
+    /**
+     * Disabling context path.
+     *
+     * @see #withContextPath(String)
+     *
+     * @return builder
+     */
+    @Nonnull
+    public Builder withNoContextPath() {
+      this.contextPath = "";
       return this;
     }
 

--- a/mock/src/main/java/com/tngtech/keycloakmock/api/TokenConfig.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/api/TokenConfig.java
@@ -31,7 +31,7 @@ import javax.annotation.Nullable;
  * }</pre>
  */
 public class TokenConfig {
-  private static final Pattern ISSUER_PATH_PATTERN = Pattern.compile("^/auth/realms/([^/]+)$");
+  private static final Pattern ISSUER_PATH_PATTERN = Pattern.compile("^.*?/realms/([^/]+)$");
 
   @Nonnull private final Set<String> audience;
   @Nonnull private final String authorizedParty;
@@ -348,7 +348,7 @@ public class TokenConfig {
             "The issuer '"
                 + issuer
                 + "' did not conform to the expected format"
-                + " 'http[s]://$HOSTNAME[:port]/auth/realms/$REALM'.");
+                + " 'http[s]://$HOSTNAME[:port][:contextPath]/realms/$REALM'.");
       }
       return matcher.group(1);
     }

--- a/mock/src/main/java/com/tngtech/keycloakmock/api/TokenConfig.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/api/TokenConfig.java
@@ -348,7 +348,7 @@ public class TokenConfig {
             "The issuer '"
                 + issuer
                 + "' did not conform to the expected format"
-                + " 'http[s]://$HOSTNAME[:port][:contextPath]/realms/$REALM'.");
+                + " 'http[s]://$HOSTNAME[:$PORT][/$CONTEXT_PATH]/realms/$REALM'.");
       }
       return matcher.group(1);
     }

--- a/mock/src/main/java/com/tngtech/keycloakmock/impl/UrlConfiguration.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/impl/UrlConfiguration.java
@@ -31,10 +31,11 @@ public class UrlConfiguration {
     } else {
       this.hostname = serverConfig.getDefaultHostname() + ":" + serverConfig.getPort();
     }
-    if (Objects.requireNonNull(serverConfig.getContextPath()).length() == 0) {
+    if (Objects.requireNonNull(serverConfig.getContextPath()).isEmpty()) {
       this.contextPath = serverConfig.getContextPath();
     } else {
-      this.contextPath = serverConfig.getContextPath().startsWith("/")
+      this.contextPath =
+          serverConfig.getContextPath().startsWith("/")
               ? serverConfig.getContextPath()
               : "/".concat(serverConfig.getContextPath());
     }

--- a/mock/src/main/java/com/tngtech/keycloakmock/impl/UrlConfiguration.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/impl/UrlConfiguration.java
@@ -8,7 +8,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class UrlConfiguration {
-  private static final String ISSUER_PATH = "/auth/realms/";
+  private static final String ISSUER_PATH = "/realms/";
   private static final String AUTHENTICATION_CALLBACK_PATH = "authenticate/";
   private static final String OUT_OF_BAND_PATH = "oob";
   private static final String ISSUER_OPEN_ID_PATH = "protocol/openid-connect/";
@@ -19,6 +19,7 @@ public class UrlConfiguration {
   @Nonnull private final Protocol protocol;
   private final int port;
   @Nonnull private final String hostname;
+  @Nonnull private final String contextPath;
   @Nonnull private final String realm;
 
   public UrlConfiguration(@Nonnull final ServerConfig serverConfig) {
@@ -30,6 +31,13 @@ public class UrlConfiguration {
     } else {
       this.hostname = serverConfig.getDefaultHostname() + ":" + serverConfig.getPort();
     }
+    if (Objects.requireNonNull(serverConfig.getContextPath()).length() == 0) {
+      this.contextPath = serverConfig.getContextPath();
+    } else {
+      this.contextPath = serverConfig.getContextPath().startsWith("/")
+              ? serverConfig.getContextPath()
+              : "/".concat(serverConfig.getContextPath());
+    }
     this.realm = Objects.requireNonNull(serverConfig.getDefaultRealm());
   }
 
@@ -40,6 +48,7 @@ public class UrlConfiguration {
     this.protocol = baseConfiguration.protocol;
     this.port = baseConfiguration.port;
     this.hostname = requestHost != null ? requestHost : baseConfiguration.hostname;
+    this.contextPath = baseConfiguration.contextPath;
     this.realm = requestRealm != null ? requestRealm : baseConfiguration.realm;
   }
 
@@ -60,12 +69,12 @@ public class UrlConfiguration {
 
   @Nonnull
   public URI getIssuer() {
-    return getBaseUrl().resolve(ISSUER_PATH + realm);
+    return getBaseUrl().resolve(contextPath + ISSUER_PATH + realm);
   }
 
   @Nonnull
   public URI getIssuerPath() {
-    return getBaseUrl().resolve(ISSUER_PATH + realm + "/");
+    return getBaseUrl().resolve(contextPath + ISSUER_PATH + realm + "/");
   }
 
   @Nonnull

--- a/mock/src/main/java/com/tngtech/keycloakmock/impl/UrlConfiguration.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/impl/UrlConfiguration.java
@@ -31,8 +31,9 @@ public class UrlConfiguration {
     } else {
       this.hostname = serverConfig.getDefaultHostname() + ":" + serverConfig.getPort();
     }
-    if (Objects.requireNonNull(serverConfig.getContextPath()).isEmpty()) {
-      this.contextPath = serverConfig.getContextPath();
+    if (Objects.requireNonNull(serverConfig.getContextPath()).isEmpty()
+        || "/".equals(serverConfig.getContextPath())) {
+      this.contextPath = "";
     } else {
       this.contextPath =
           serverConfig.getContextPath().startsWith("/")

--- a/mock/src/test/java/com/tngtech/keycloakmock/api/TokenConfigTest.java
+++ b/mock/src/test/java/com/tngtech/keycloakmock/api/TokenConfigTest.java
@@ -301,6 +301,7 @@ class TokenConfigTest {
     Builder builder = aTokenConfig();
     assertThatThrownBy(() -> builder.withSourceToken(TOKEN_WITH_UNEXPECTED_ISSUER_URL))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("did not conform to the expected format");
+        .hasMessageContaining("did not conform to the expected format")
+        .hasMessageContaining("'http[s]://$HOSTNAME[:port][:contextPath]/realms/$REALM'");
   }
 }

--- a/mock/src/test/java/com/tngtech/keycloakmock/api/TokenConfigTest.java
+++ b/mock/src/test/java/com/tngtech/keycloakmock/api/TokenConfigTest.java
@@ -302,6 +302,6 @@ class TokenConfigTest {
     assertThatThrownBy(() -> builder.withSourceToken(TOKEN_WITH_UNEXPECTED_ISSUER_URL))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("did not conform to the expected format")
-        .hasMessageContaining("'http[s]://$HOSTNAME[:port][:contextPath]/realms/$REALM'");
+        .hasMessageContaining("'http[s]://$HOSTNAME[:$PORT][/$CONTEXT_PATH]/realms/$REALM'");
   }
 }

--- a/mock/src/test/java/com/tngtech/keycloakmock/impl/UrlConfigurationTest.java
+++ b/mock/src/test/java/com/tngtech/keycloakmock/impl/UrlConfigurationTest.java
@@ -30,13 +30,7 @@ class UrlConfigurationTest {
         Arguments.of(aServerConfig().withPort(80).build(), "http://localhost"),
         Arguments.of(aServerConfig().withPort(443).build(), "http://localhost:443"),
         Arguments.of(aServerConfig().withTls(true).withPort(80).build(), "https://localhost:80"),
-        Arguments.of(aServerConfig().withTls(true).withPort(443).build(), "https://localhost"),
-        Arguments.of(aServerConfig().withNoContextPath().build(), "http://localhost:8000"),
-        Arguments.of(aServerConfig().withContextPath("auth").build(), "http://localhost:8000"),
-        Arguments.of(aServerConfig().withContextPath("/auth").build(), "http://localhost:8000"),
-        Arguments.of(aServerConfig().withContextPath("/context-path").build(), "http://localhost:8000"),
-        Arguments.of(aServerConfig().withContextPath("complex/context/path").build(), "http://localhost:8000")
-    );
+        Arguments.of(aServerConfig().withTls(true).withPort(443).build(), "https://localhost"));
   }
 
   private static Stream<Arguments> server_config_and_expected_issuer_url() {
@@ -52,20 +46,20 @@ class UrlConfigurationTest {
         Arguments.of(
             aServerConfig().withTls(true).withPort(443).build(),
             "https://localhost/auth/realms/master"),
-        Arguments.of(aServerConfig().withNoContextPath().build(), "http://localhost:8000/realms/master"),
+        Arguments.of(
+            aServerConfig().withNoContextPath().build(), "http://localhost:8000/realms/master"),
         Arguments.of(
             aServerConfig().withContextPath("auth").build(),
-                "http://localhost:8000/auth/realms/master"),
+            "http://localhost:8000/auth/realms/master"),
         Arguments.of(
             aServerConfig().withContextPath("/auth").build(),
-                "http://localhost:8000/auth/realms/master"),
+            "http://localhost:8000/auth/realms/master"),
         Arguments.of(
             aServerConfig().withContextPath("/context-path").build(),
-                "http://localhost:8000/context-path/realms/master"),
+            "http://localhost:8000/context-path/realms/master"),
         Arguments.of(
-                aServerConfig().withContextPath("complex/context/path").build(),
-                "http://localhost:8000/complex/context/path/realms/master")
-    );
+            aServerConfig().withContextPath("complex/context/path").build(),
+            "http://localhost:8000/complex/context/path/realms/master"));
   }
 
   private static Stream<Arguments> request_host_and_realm_and_expected() {
@@ -79,23 +73,23 @@ class UrlConfigurationTest {
   private static Stream<Arguments> request_host_and_realm_and_expected_with_no_context_path() {
     return Stream.of(
         Arguments.of(
-            REQUEST_HOST_NO_CONTEXT_PATH, null,
-            "http://requestHostNoContextPath/realms/master"),
+            REQUEST_HOST_NO_CONTEXT_PATH, null, "http://requestHostNoContextPath/realms/master"),
         Arguments.of(
-            REQUEST_HOST_NO_CONTEXT_PATH, REQUEST_REALM,
-            "http://requestHostNoContextPath/realms/requestRealm")
-    );
+            REQUEST_HOST_NO_CONTEXT_PATH,
+            REQUEST_REALM,
+            "http://requestHostNoContextPath/realms/requestRealm"));
   }
 
   private static Stream<Arguments> request_host_and_realm_and_expected_with_custom_context_path() {
     return Stream.of(
         Arguments.of(
-            REQUEST_HOST_CUSTOM_CONTEXT_PATH, null,
+            REQUEST_HOST_CUSTOM_CONTEXT_PATH,
+            null,
             "http://requestHostCustomContextPath/custom/context/path/realms/master"),
         Arguments.of(
-            REQUEST_HOST_CUSTOM_CONTEXT_PATH, REQUEST_REALM,
-            "http://requestHostCustomContextPath/custom/context/path/realms/requestRealm")
-    );
+            REQUEST_HOST_CUSTOM_CONTEXT_PATH,
+            REQUEST_REALM,
+            "http://requestHostCustomContextPath/custom/context/path/realms/requestRealm"));
   }
 
   @ParameterizedTest
@@ -127,10 +121,10 @@ class UrlConfigurationTest {
   @ParameterizedTest
   @MethodSource("request_host_and_realm_and_expected_with_no_context_path")
   void context_parameters_are_used_correctly_for_server_config_with_no_context_path(
-          String requestHost, String requestRealm, String expected) {
-    urlConfiguration = new UrlConfiguration(
-        aServerConfig().withNoContextPath().build()
-    ).forRequestContext(requestHost, requestRealm);
+      String requestHost, String requestRealm, String expected) {
+    urlConfiguration =
+        new UrlConfiguration(aServerConfig().withNoContextPath().build())
+            .forRequestContext(requestHost, requestRealm);
 
     assertThat(urlConfiguration.getIssuer()).hasToString(expected);
   }
@@ -138,10 +132,10 @@ class UrlConfigurationTest {
   @ParameterizedTest
   @MethodSource("request_host_and_realm_and_expected_with_custom_context_path")
   void context_parameters_are_used_correctly_for_server_config_with_custom_context_path(
-          String requestHost, String requestRealm, String expected) {
-    urlConfiguration = new UrlConfiguration(
-            aServerConfig().withContextPath("custom/context/path").build()
-    ).forRequestContext(requestHost, requestRealm);
+      String requestHost, String requestRealm, String expected) {
+    urlConfiguration =
+        new UrlConfiguration(aServerConfig().withContextPath("custom/context/path").build())
+            .forRequestContext(requestHost, requestRealm);
 
     assertThat(urlConfiguration.getIssuer()).hasToString(expected);
   }
@@ -184,20 +178,26 @@ class UrlConfigurationTest {
 
   @Test
   void urls_are_correct_with_custom_context_path() {
-    urlConfiguration = new UrlConfiguration(aServerConfig().withContextPath("/custom/context/path").build());
+    urlConfiguration =
+        new UrlConfiguration(aServerConfig().withContextPath("/custom/context/path").build());
 
     assertThat(urlConfiguration.getIssuerPath())
         .hasToString("http://localhost:8000/custom/context/path/realms/master/");
     assertThat(urlConfiguration.getOpenIdPath("1234"))
-        .hasToString("http://localhost:8000/custom/context/path/realms/master/protocol/openid-connect/1234");
+        .hasToString(
+            "http://localhost:8000/custom/context/path/realms/master/protocol/openid-connect/1234");
     assertThat(urlConfiguration.getAuthorizationEndpoint())
-        .hasToString("http://localhost:8000/custom/context/path/realms/master/protocol/openid-connect/auth");
+        .hasToString(
+            "http://localhost:8000/custom/context/path/realms/master/protocol/openid-connect/auth");
     assertThat(urlConfiguration.getEndSessionEndpoint())
-        .hasToString("http://localhost:8000/custom/context/path/realms/master/protocol/openid-connect/logout");
+        .hasToString(
+            "http://localhost:8000/custom/context/path/realms/master/protocol/openid-connect/logout");
     assertThat(urlConfiguration.getJwksUri())
-        .hasToString("http://localhost:8000/custom/context/path/realms/master/protocol/openid-connect/certs");
+        .hasToString(
+            "http://localhost:8000/custom/context/path/realms/master/protocol/openid-connect/certs");
     assertThat(urlConfiguration.getTokenEndpoint())
-        .hasToString("http://localhost:8000/custom/context/path/realms/master/protocol/openid-connect/token");
+        .hasToString(
+            "http://localhost:8000/custom/context/path/realms/master/protocol/openid-connect/token");
   }
 
   @Test

--- a/mock/src/test/java/com/tngtech/keycloakmock/impl/UrlConfigurationTest.java
+++ b/mock/src/test/java/com/tngtech/keycloakmock/impl/UrlConfigurationTest.java
@@ -15,6 +15,8 @@ class UrlConfigurationTest {
   private static final String DEFAULT_HOSTNAME = "defaultHost";
   private static final String DEFAULT_REALM = "defaultRealm";
   private static final String REQUEST_HOST = "requestHost";
+  private static final String REQUEST_HOST_NO_CONTEXT_PATH = "requestHostNoContextPath";
+  private static final String REQUEST_HOST_CUSTOM_CONTEXT_PATH = "requestHostCustomContextPath";
   private static final String REQUEST_REALM = "requestRealm";
 
   private UrlConfiguration urlConfiguration;
@@ -28,7 +30,13 @@ class UrlConfigurationTest {
         Arguments.of(aServerConfig().withPort(80).build(), "http://localhost"),
         Arguments.of(aServerConfig().withPort(443).build(), "http://localhost:443"),
         Arguments.of(aServerConfig().withTls(true).withPort(80).build(), "https://localhost:80"),
-        Arguments.of(aServerConfig().withTls(true).withPort(443).build(), "https://localhost"));
+        Arguments.of(aServerConfig().withTls(true).withPort(443).build(), "https://localhost"),
+        Arguments.of(aServerConfig().withNoContextPath().build(), "http://localhost:8000"),
+        Arguments.of(aServerConfig().withContextPath("auth").build(), "http://localhost:8000"),
+        Arguments.of(aServerConfig().withContextPath("/auth").build(), "http://localhost:8000"),
+        Arguments.of(aServerConfig().withContextPath("/context-path").build(), "http://localhost:8000"),
+        Arguments.of(aServerConfig().withContextPath("complex/context/path").build(), "http://localhost:8000")
+    );
   }
 
   private static Stream<Arguments> server_config_and_expected_issuer_url() {
@@ -43,7 +51,21 @@ class UrlConfigurationTest {
         Arguments.of(aServerConfig().withPort(80).build(), "http://localhost/auth/realms/master"),
         Arguments.of(
             aServerConfig().withTls(true).withPort(443).build(),
-            "https://localhost/auth/realms/master"));
+            "https://localhost/auth/realms/master"),
+        Arguments.of(aServerConfig().withNoContextPath().build(), "http://localhost:8000/realms/master"),
+        Arguments.of(
+            aServerConfig().withContextPath("auth").build(),
+                "http://localhost:8000/auth/realms/master"),
+        Arguments.of(
+            aServerConfig().withContextPath("/auth").build(),
+                "http://localhost:8000/auth/realms/master"),
+        Arguments.of(
+            aServerConfig().withContextPath("/context-path").build(),
+                "http://localhost:8000/context-path/realms/master"),
+        Arguments.of(
+                aServerConfig().withContextPath("complex/context/path").build(),
+                "http://localhost:8000/complex/context/path/realms/master")
+    );
   }
 
   private static Stream<Arguments> request_host_and_realm_and_expected() {
@@ -52,6 +74,28 @@ class UrlConfigurationTest {
         Arguments.of(REQUEST_HOST, null, "http://requestHost/auth/realms/master"),
         Arguments.of(null, REQUEST_REALM, "http://localhost:8000/auth/realms/requestRealm"),
         Arguments.of(REQUEST_HOST, REQUEST_REALM, "http://requestHost/auth/realms/requestRealm"));
+  }
+
+  private static Stream<Arguments> request_host_and_realm_and_expected_with_no_context_path() {
+    return Stream.of(
+        Arguments.of(
+            REQUEST_HOST_NO_CONTEXT_PATH, null,
+            "http://requestHostNoContextPath/realms/master"),
+        Arguments.of(
+            REQUEST_HOST_NO_CONTEXT_PATH, REQUEST_REALM,
+            "http://requestHostNoContextPath/realms/requestRealm")
+    );
+  }
+
+  private static Stream<Arguments> request_host_and_realm_and_expected_with_custom_context_path() {
+    return Stream.of(
+        Arguments.of(
+            REQUEST_HOST_CUSTOM_CONTEXT_PATH, null,
+            "http://requestHostCustomContextPath/custom/context/path/realms/master"),
+        Arguments.of(
+            REQUEST_HOST_CUSTOM_CONTEXT_PATH, REQUEST_REALM,
+            "http://requestHostCustomContextPath/custom/context/path/realms/requestRealm")
+    );
   }
 
   @ParameterizedTest
@@ -80,6 +124,28 @@ class UrlConfigurationTest {
     assertThat(urlConfiguration.getIssuer()).hasToString(expected);
   }
 
+  @ParameterizedTest
+  @MethodSource("request_host_and_realm_and_expected_with_no_context_path")
+  void context_parameters_are_used_correctly_for_server_config_with_no_context_path(
+          String requestHost, String requestRealm, String expected) {
+    urlConfiguration = new UrlConfiguration(
+        aServerConfig().withNoContextPath().build()
+    ).forRequestContext(requestHost, requestRealm);
+
+    assertThat(urlConfiguration.getIssuer()).hasToString(expected);
+  }
+
+  @ParameterizedTest
+  @MethodSource("request_host_and_realm_and_expected_with_custom_context_path")
+  void context_parameters_are_used_correctly_for_server_config_with_custom_context_path(
+          String requestHost, String requestRealm, String expected) {
+    urlConfiguration = new UrlConfiguration(
+            aServerConfig().withContextPath("custom/context/path").build()
+    ).forRequestContext(requestHost, requestRealm);
+
+    assertThat(urlConfiguration.getIssuer()).hasToString(expected);
+  }
+
   @Test
   void urls_are_correct() {
     urlConfiguration = new UrlConfiguration(aServerConfig().build());
@@ -96,6 +162,42 @@ class UrlConfigurationTest {
         .hasToString("http://localhost:8000/auth/realms/master/protocol/openid-connect/certs");
     assertThat(urlConfiguration.getTokenEndpoint())
         .hasToString("http://localhost:8000/auth/realms/master/protocol/openid-connect/token");
+  }
+
+  @Test
+  void urls_are_correct_with_no_context_path() {
+    urlConfiguration = new UrlConfiguration(aServerConfig().withNoContextPath().build());
+
+    assertThat(urlConfiguration.getIssuerPath())
+        .hasToString("http://localhost:8000/realms/master/");
+    assertThat(urlConfiguration.getOpenIdPath("1234"))
+        .hasToString("http://localhost:8000/realms/master/protocol/openid-connect/1234");
+    assertThat(urlConfiguration.getAuthorizationEndpoint())
+        .hasToString("http://localhost:8000/realms/master/protocol/openid-connect/auth");
+    assertThat(urlConfiguration.getEndSessionEndpoint())
+        .hasToString("http://localhost:8000/realms/master/protocol/openid-connect/logout");
+    assertThat(urlConfiguration.getJwksUri())
+        .hasToString("http://localhost:8000/realms/master/protocol/openid-connect/certs");
+    assertThat(urlConfiguration.getTokenEndpoint())
+        .hasToString("http://localhost:8000/realms/master/protocol/openid-connect/token");
+  }
+
+  @Test
+  void urls_are_correct_with_custom_context_path() {
+    urlConfiguration = new UrlConfiguration(aServerConfig().withContextPath("/custom/context/path").build());
+
+    assertThat(urlConfiguration.getIssuerPath())
+        .hasToString("http://localhost:8000/custom/context/path/realms/master/");
+    assertThat(urlConfiguration.getOpenIdPath("1234"))
+        .hasToString("http://localhost:8000/custom/context/path/realms/master/protocol/openid-connect/1234");
+    assertThat(urlConfiguration.getAuthorizationEndpoint())
+        .hasToString("http://localhost:8000/custom/context/path/realms/master/protocol/openid-connect/auth");
+    assertThat(urlConfiguration.getEndSessionEndpoint())
+        .hasToString("http://localhost:8000/custom/context/path/realms/master/protocol/openid-connect/logout");
+    assertThat(urlConfiguration.getJwksUri())
+        .hasToString("http://localhost:8000/custom/context/path/realms/master/protocol/openid-connect/certs");
+    assertThat(urlConfiguration.getTokenEndpoint())
+        .hasToString("http://localhost:8000/custom/context/path/realms/master/protocol/openid-connect/token");
   }
 
   @Test

--- a/standalone/src/main/java/com/tngtech/keycloakmock/standalone/Main.java
+++ b/standalone/src/main/java/com/tngtech/keycloakmock/standalone/Main.java
@@ -35,8 +35,9 @@ public class Main implements Callable<Void> {
   @SuppressWarnings("FieldMayBeFinal")
   @Option(
       names = {"-cp", "--contextPath"},
-      description = "Keycloak context path (default: ${DEFAULT-VALUE}). " +
-          "If present, must be prefixed with '/', eg. --contextPath=/example-path")
+      description =
+          "Keycloak context path (default: ${DEFAULT-VALUE}). "
+              + "If present, must be prefixed with '/', eg. --contextPath=/example-path")
   private String contextPath = "/auth";
 
   @SuppressWarnings("FieldMayBeFinal")
@@ -75,11 +76,11 @@ public class Main implements Callable<Void> {
                 .build())
         .start();
 
-    LOG.info("Server is running on {}://localhost:{}{}",
+    LOG.info(
+        "Server is running on {}://localhost:{}{}",
         (tls ? "https" : "http"),
         port,
-        usedContextPath
-    );
+        usedContextPath);
 
     return null;
   }

--- a/standalone/src/main/java/com/tngtech/keycloakmock/standalone/Main.java
+++ b/standalone/src/main/java/com/tngtech/keycloakmock/standalone/Main.java
@@ -35,7 +35,8 @@ public class Main implements Callable<Void> {
   @SuppressWarnings("FieldMayBeFinal")
   @Option(
       names = {"-cp", "--contextPath"},
-      description = "Keycloak context path (default: ${DEFAULT-VALUE}).")
+      description = "Keycloak context path (default: ${DEFAULT-VALUE}). " +
+          "If present, must be prefixed with '/', eg. --contextPath=/example-path")
   private String contextPath = "/auth";
 
   @SuppressWarnings("FieldMayBeFinal")
@@ -63,15 +64,23 @@ public class Main implements Callable<Void> {
 
   @Override
   public Void call() {
+    String usedContextPath = noContextPath ? "" : contextPath;
+
     new KeycloakMock(
             aServerConfig()
                 .withPort(port)
                 .withTls(tls)
-                .withContextPath(noContextPath ? "" : contextPath)
+                .withContextPath(usedContextPath)
                 .withResourcesToMapRolesTo(resourcesToMapRolesTo)
                 .build())
         .start();
-    LOG.info("Server is running on {}://localhost:{}{}", (tls ? "https" : "http"), contextPath, port);
+
+    LOG.info("Server is running on {}://localhost:{}{}",
+        (tls ? "https" : "http"),
+        port,
+        usedContextPath
+    );
+
     return null;
   }
 }

--- a/standalone/src/main/java/com/tngtech/keycloakmock/standalone/Main.java
+++ b/standalone/src/main/java/com/tngtech/keycloakmock/standalone/Main.java
@@ -35,13 +35,13 @@ public class Main implements Callable<Void> {
   @SuppressWarnings("FieldMayBeFinal")
   @Option(
       names = {"-cp", "--contextPath"},
-      description = "Keycloak context path.")
+      description = "Keycloak context path (default: ${DEFAULT-VALUE}).")
   private String contextPath = "/auth";
 
   @SuppressWarnings("FieldMayBeFinal")
   @Option(
       names = {"-ncp", "--noContextPath"},
-      description = "Keycloak context path.")
+      description = "If present context path will not be used. Good for mocking Keycloak 18.0.0+.")
   private boolean noContextPath;
 
   @Option(

--- a/standalone/src/main/java/com/tngtech/keycloakmock/standalone/Main.java
+++ b/standalone/src/main/java/com/tngtech/keycloakmock/standalone/Main.java
@@ -32,6 +32,18 @@ public class Main implements Callable<Void> {
       description = "Whether to use HTTPS instead of HTTP.")
   private boolean tls;
 
+  @SuppressWarnings("FieldMayBeFinal")
+  @Option(
+      names = {"-cp", "--contextPath"},
+      description = "Keycloak context path.")
+  private String contextPath = "/auth";
+
+  @SuppressWarnings("FieldMayBeFinal")
+  @Option(
+      names = {"-ncp", "--noContextPath"},
+      description = "Keycloak context path.")
+  private boolean noContextPath;
+
   @Option(
       names = {"-r", "--mapRolesToResources"},
       description = "If set, roles will be assigned to these resources instead of the realm.",
@@ -55,10 +67,11 @@ public class Main implements Callable<Void> {
             aServerConfig()
                 .withPort(port)
                 .withTls(tls)
+                .withContextPath(noContextPath ? "" : contextPath)
                 .withResourcesToMapRolesTo(resourcesToMapRolesTo)
                 .build())
         .start();
-    LOG.info("Server is running on {}://localhost:{}", (tls ? "https" : "http"), port);
+    LOG.info("Server is running on {}://localhost:{}{}", (tls ? "https" : "http"), contextPath, port);
     return null;
   }
 }


### PR DESCRIPTION
Hi, I've added support for disabling or overriding `/auth` context path so that mock can be used with Keycloak 18.0.0+