### PR TITLE
use base-64 encoding without padding

### DIFF
--- a/mock/src/main/java/com/tngtech/keycloakmock/impl/handler/JwksRoute.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/impl/handler/JwksRoute.java
@@ -48,17 +48,30 @@ public class JwksRoute implements Handler<RoutingContext> {
     if (publicKey instanceof RSAPublicKey) {
       result.put("kty", "RSA");
       RSAPublicKey rsaKey = (RSAPublicKey) publicKey;
-      result.put("n", Base64.getUrlEncoder().encodeToString(rsaKey.getModulus().toByteArray()));
       result.put(
-          "e", Base64.getUrlEncoder().encodeToString(rsaKey.getPublicExponent().toByteArray()));
+          "n",
+          Base64.getUrlEncoder()
+              .withoutPadding()
+              .encodeToString(rsaKey.getModulus().toByteArray()));
+      result.put(
+          "e",
+          Base64.getUrlEncoder()
+              .withoutPadding()
+              .encodeToString(rsaKey.getPublicExponent().toByteArray()));
     } else if (publicKey instanceof ECPublicKey) {
       result.put("kty", "EC");
       ECPublicKey ecKey = (ECPublicKey) publicKey;
       result.put("crv", "P-" + ecKey.getParams().getOrder().bitLength());
       result.put(
-          "x", Base64.getUrlEncoder().encodeToString(ecKey.getW().getAffineX().toByteArray()));
+          "x",
+          Base64.getUrlEncoder()
+              .withoutPadding()
+              .encodeToString(ecKey.getW().getAffineX().toByteArray()));
       result.put(
-          "y", Base64.getUrlEncoder().encodeToString(ecKey.getW().getAffineY().toByteArray()));
+          "y",
+          Base64.getUrlEncoder()
+              .withoutPadding()
+              .encodeToString(ecKey.getW().getAffineY().toByteArray()));
     } else {
       throw new IllegalStateException("Invalid public key type found");
     }

--- a/mock/src/test/java/com/tngtech/keycloakmock/impl/handler/JwksRouteTest.java
+++ b/mock/src/test/java/com/tngtech/keycloakmock/impl/handler/JwksRouteTest.java
@@ -33,7 +33,7 @@ class JwksRouteTest extends HandlerTestBase {
         .hasFieldOrPropertyWithValue("use", "sig")
         .hasFieldOrPropertyWithValue(
             "n",
-            "AKzaf4nijuwtAn9ieZaz-iGXBp1pFm6dJMAxRO6ax2CV9cBFeThxrKJNFmDY7j7gKRnrgWxvgJKSd3hAm_CGmXHbTM8cPi_gsof-CsOohv7LH0UYbr0UpCIJncTiRrKQto7q_NOO4Jh1EBSLMPX7MzttEhh35Ue9txHLq3zkdkR6BR6nGS7QxEg7FzYzA4IooV59OPr-TvlDxbEpwc1wkRZDGavo-WjngAt7m_BEQtHnav3whitbrMmi_1tWY8cQbO9D4FuQTM7yvACLSv94G2TCvsjm_gGJmOJyRBkI1r-uEIfhz9-VIKlswqapKSul-Hoxv5NycucRa4xi4N39dfM=")
+            "AKzaf4nijuwtAn9ieZaz-iGXBp1pFm6dJMAxRO6ax2CV9cBFeThxrKJNFmDY7j7gKRnrgWxvgJKSd3hAm_CGmXHbTM8cPi_gsof-CsOohv7LH0UYbr0UpCIJncTiRrKQto7q_NOO4Jh1EBSLMPX7MzttEhh35Ue9txHLq3zkdkR6BR6nGS7QxEg7FzYzA4IooV59OPr-TvlDxbEpwc1wkRZDGavo-WjngAt7m_BEQtHnav3whitbrMmi_1tWY8cQbO9D4FuQTM7yvACLSv94G2TCvsjm_gGJmOJyRBkI1r-uEIfhz9-VIKlswqapKSul-Hoxv5NycucRa4xi4N39dfM")
         .hasFieldOrPropertyWithValue("e", "AQAB");
   }
 


### PR DESCRIPTION
The spec states (see https://datatracker.ietf.org/doc/html/rfc7515#appendix-C) that all trailing '=' characters should be omitted.

Resolves #144