### PR TITLE
Added ability to set token's lifespan for server mode

### DIFF
--- a/mock/src/main/java/com/tngtech/keycloakmock/api/ServerConfig.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/api/ServerConfig.java
@@ -1,6 +1,8 @@
 package com.tngtech.keycloakmock.api;
 
 import com.tngtech.keycloakmock.impl.Protocol;
+
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -17,6 +19,7 @@ public final class ServerConfig {
   private static final int DEFAULT_PORT = 8000;
   private static final String DEFAULT_REALM = "master";
   private static final String DEFAULT_SCOPE = "openid";
+  private static final Duration DEFAULT_TOKEN_LIFESPAN = Duration.ofHours(10);
 
   private final int port;
   @Nonnull private final Protocol protocol;
@@ -25,6 +28,7 @@ public final class ServerConfig {
   @Nonnull private final String defaultRealm;
   @Nonnull private final List<String> resourcesToMapRolesTo;
   @Nonnull private final Set<String> defaultScopes;
+  @Nonnull private final Duration tokenLifespan;
 
   private ServerConfig(@Nonnull final Builder builder) {
     this.port = builder.port;
@@ -34,6 +38,7 @@ public final class ServerConfig {
     this.defaultRealm = builder.defaultRealm;
     this.resourcesToMapRolesTo = builder.resourcesToMapRolesTo;
     this.defaultScopes = builder.defaultScopes;
+    this.tokenLifespan = builder.tokenLifespan;
   }
 
   /**
@@ -149,6 +154,16 @@ public final class ServerConfig {
   }
 
   /**
+   * Get access token lifespan
+   *
+   * @return token lifespan
+   */
+  @Nonnull
+  public Duration getTokenLifespan() {
+    return tokenLifespan;
+  }
+
+  /**
    * Builder for {@link ServerConfig}.
    *
    * <p>Use this to generate a server configuration to your needs.
@@ -162,6 +177,7 @@ public final class ServerConfig {
     @Nonnull private String defaultRealm = DEFAULT_REALM;
     @Nonnull private final List<String> resourcesToMapRolesTo = new ArrayList<>();
     @Nonnull private final Set<String> defaultScopes = new HashSet<>();
+    @Nonnull private Duration tokenLifespan = DEFAULT_TOKEN_LIFESPAN;
 
     private Builder() {
       defaultScopes.add(DEFAULT_SCOPE);
@@ -362,6 +378,20 @@ public final class ServerConfig {
     @Nonnull
     public Builder withDefaultScope(@Nonnull final String defaultScope) {
       this.defaultScopes.add(defaultScope);
+      return this;
+    }
+
+    /**
+     * Set default access token lifespan ("exp" filed will be set as issuedAt + tokenLifespan)
+     * By default lifespan 10 hours.
+     *
+     * @param tokenLifespan as duration
+     * @return builder
+     *
+     */
+    @Nonnull
+    public Builder withTokenLifespan(@Nonnull final Duration tokenLifespan) {
+      this.tokenLifespan = tokenLifespan;
       return this;
     }
 

--- a/mock/src/main/java/com/tngtech/keycloakmock/api/ServerConfig.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/api/ServerConfig.java
@@ -1,7 +1,6 @@
 package com.tngtech.keycloakmock.api;
 
 import com.tngtech.keycloakmock.impl.Protocol;
-
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -382,12 +381,11 @@ public final class ServerConfig {
     }
 
     /**
-     * Set default access token lifespan ("exp" filed will be set as issuedAt + tokenLifespan)
-     * By default lifespan 10 hours.
+     * Set default access token lifespan ("exp" filed will be set as issuedAt + tokenLifespan). + By
+     * default lifespan 10 hours.
      *
      * @param tokenLifespan as duration
      * @return builder
-     *
      */
     @Nonnull
     public Builder withTokenLifespan(@Nonnull final Duration tokenLifespan) {

--- a/mock/src/main/java/com/tngtech/keycloakmock/api/TokenConfig.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/api/TokenConfig.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -761,6 +762,11 @@ public class TokenConfig {
     @Nonnull
     public TokenConfig build() {
       return new TokenConfig(this);
+    }
+
+    public Builder witTokenLifespan(Duration tokenLifespan) {
+      this.expiration = issuedAt.plus(tokenLifespan);
+      return this;
     }
   }
 

--- a/mock/src/main/java/com/tngtech/keycloakmock/impl/dagger/ServerModule.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/impl/dagger/ServerModule.java
@@ -35,6 +35,7 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
+import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
@@ -94,6 +95,13 @@ public class ServerModule {
   @Named("scopes")
   public Set<String> provideScopes(@Nonnull ServerConfig serverConfig) {
     return serverConfig.getDefaultScopes();
+  }
+
+  @Provides
+  @Singleton
+  @Named("tokenLifespan")
+  public Duration provideTokenLifespan(@Nonnull ServerConfig serverConfig) {
+    return serverConfig.getTokenLifespan();
   }
 
   @Provides

--- a/mock/src/main/java/com/tngtech/keycloakmock/impl/helper/TokenHelper.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/impl/helper/TokenHelper.java
@@ -7,6 +7,8 @@ import com.tngtech.keycloakmock.impl.TokenGenerator;
 import com.tngtech.keycloakmock.impl.UrlConfiguration;
 import com.tngtech.keycloakmock.impl.session.Session;
 import com.tngtech.keycloakmock.impl.session.UserData;
+
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -26,14 +28,18 @@ public class TokenHelper {
   @Nonnull private final List<String> resourcesToMapRolesTo;
   @Nonnull private final Set<String> defaultScopes;
 
+  @Nonnull private final Duration tokenLifespan;
+
   @Inject
   TokenHelper(
-      @Nonnull TokenGenerator tokenGenerator,
-      @Nonnull @Named("resources") List<String> resourcesToMapRolesTo,
-      @Nonnull @Named("scopes") Set<String> defaultScopes) {
+          @Nonnull TokenGenerator tokenGenerator,
+          @Nonnull @Named("resources") List<String> resourcesToMapRolesTo,
+          @Nonnull @Named("scopes") Set<String> defaultScopes,
+          @Nonnull @Named("tokenLifespan") Duration tokenLifespan) {
     this.tokenGenerator = tokenGenerator;
     this.resourcesToMapRolesTo = resourcesToMapRolesTo;
     this.defaultScopes = defaultScopes;
+    this.tokenLifespan = tokenLifespan;
   }
 
   @Nullable
@@ -53,7 +59,8 @@ public class TokenHelper {
             .withClaim(SESSION_STATE, session.getSessionId())
             // we currently don't do proper authorization anyway, so we can just act as if we were
             // compliant to ISO/IEC 29115 level 1 (see KEYCLOAK-3223 / KEYCLOAK-3314)
-            .withAuthenticationContextClassReference("1");
+            .withAuthenticationContextClassReference("1")
+            .witTokenLifespan(tokenLifespan);
     if (session.getNonce() != null) {
       builder.withClaim(NONCE, session.getNonce());
     }

--- a/mock/src/main/java/com/tngtech/keycloakmock/impl/helper/TokenHelper.java
+++ b/mock/src/main/java/com/tngtech/keycloakmock/impl/helper/TokenHelper.java
@@ -7,7 +7,6 @@ import com.tngtech.keycloakmock.impl.TokenGenerator;
 import com.tngtech.keycloakmock.impl.UrlConfiguration;
 import com.tngtech.keycloakmock.impl.session.Session;
 import com.tngtech.keycloakmock.impl.session.UserData;
-
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -32,10 +31,10 @@ public class TokenHelper {
 
   @Inject
   TokenHelper(
-          @Nonnull TokenGenerator tokenGenerator,
-          @Nonnull @Named("resources") List<String> resourcesToMapRolesTo,
-          @Nonnull @Named("scopes") Set<String> defaultScopes,
-          @Nonnull @Named("tokenLifespan") Duration tokenLifespan) {
+      @Nonnull TokenGenerator tokenGenerator,
+      @Nonnull @Named("resources") List<String> resourcesToMapRolesTo,
+      @Nonnull @Named("scopes") Set<String> defaultScopes,
+      @Nonnull @Named("tokenLifespan") Duration tokenLifespan) {
     this.tokenGenerator = tokenGenerator;
     this.resourcesToMapRolesTo = resourcesToMapRolesTo;
     this.defaultScopes = defaultScopes;

--- a/mock/src/test/java/com/tngtech/keycloakmock/impl/helper/TokenHelperTest.java
+++ b/mock/src/test/java/com/tngtech/keycloakmock/impl/helper/TokenHelperTest.java
@@ -56,7 +56,9 @@ class TokenHelperTest {
 
   @Test
   void token_is_correctly_generated() {
-    uut = new TokenHelper(tokenGenerator, Collections.emptyList(), Collections.emptySet(), Duration.ofHours(100));
+    uut =
+        new TokenHelper(
+            tokenGenerator, Collections.emptyList(), Collections.emptySet(), Duration.ofHours(100));
 
     uut.getToken(session, urlConfiguration);
 
@@ -83,7 +85,9 @@ class TokenHelperTest {
 
   @Test
   void resource_roles_are_used_if_configured() {
-    uut = new TokenHelper(tokenGenerator, CONFIGURED_RESOURCES, Collections.emptySet(), Duration.ofHours(10));
+    uut =
+        new TokenHelper(
+            tokenGenerator, CONFIGURED_RESOURCES, Collections.emptySet(), Duration.ofHours(10));
 
     uut.getToken(session, urlConfiguration);
 

--- a/mock/src/test/java/com/tngtech/keycloakmock/impl/helper/TokenHelperTest.java
+++ b/mock/src/test/java/com/tngtech/keycloakmock/impl/helper/TokenHelperTest.java
@@ -10,6 +10,7 @@ import com.tngtech.keycloakmock.impl.TokenGenerator;
 import com.tngtech.keycloakmock.impl.UrlConfiguration;
 import com.tngtech.keycloakmock.impl.session.PersistentSession;
 import com.tngtech.keycloakmock.impl.session.UserData;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -55,7 +56,7 @@ class TokenHelperTest {
 
   @Test
   void token_is_correctly_generated() {
-    uut = new TokenHelper(tokenGenerator, Collections.emptyList(), Collections.emptySet());
+    uut = new TokenHelper(tokenGenerator, Collections.emptyList(), Collections.emptySet(), Duration.ofHours(100));
 
     uut.getToken(session, urlConfiguration);
 
@@ -68,7 +69,7 @@ class TokenHelperTest {
     assertThat(tokenConfig.getClaims())
         .containsEntry("nonce", NONCE)
         .containsEntry("session_state", SESSION_ID);
-    assertThat(tokenConfig.getExpiration()).isAfter(Instant.now().plus(9, ChronoUnit.HOURS));
+    assertThat(tokenConfig.getExpiration()).isAfter(Instant.now().plus(99, ChronoUnit.HOURS));
     assertThat(tokenConfig.getGivenName()).isEqualTo(USER.getGivenName());
     assertThat(tokenConfig.getFamilyName()).isEqualTo(USER.getFamilyName());
     assertThat(tokenConfig.getName()).isEqualTo(USER.getName());
@@ -82,7 +83,7 @@ class TokenHelperTest {
 
   @Test
   void resource_roles_are_used_if_configured() {
-    uut = new TokenHelper(tokenGenerator, CONFIGURED_RESOURCES, Collections.emptySet());
+    uut = new TokenHelper(tokenGenerator, CONFIGURED_RESOURCES, Collections.emptySet(), Duration.ofHours(10));
 
     uut.getToken(session, urlConfiguration);
 


### PR DESCRIPTION
Hi,

subj

In some cases we need checks refresh/401 in tests. For this case we need configure exp field for server mode.

Here the little changes that add this funtionality.