### PR TITLE
update vertx version to 4.5.30

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ ext {
     picocli_version = '4.7.7'
     slf4j_version = '2.0.17'
     // starting from major version 5, vert.x needs Java 11+
-    vertx_version = '4.5.24'
+    vertx_version = '4.5.30'
 
     license_name = 'The Apache License, Version 2.0'
     license_url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'


### PR DESCRIPTION
Vulnerability CVE-2026-6860 has been fixed in 4.5.27
I'd suggest upgrading to the latest version of the Vertx dependencies.
What do you think?